### PR TITLE
refactor(game-mode): refactor the whole game mode logic

### DIFF
--- a/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/flow/action/GameAction.java
+++ b/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/flow/action/GameAction.java
@@ -52,6 +52,12 @@ public sealed interface GameAction {
 
     }
 
+    record RotateArena(
+            String reason
+    ) implements GameAction {
+
+    }
+
     record EndGameAndBackToHub(
             Set<UUID> players,
             String reason

--- a/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/flow/action/GameAction.java
+++ b/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/flow/action/GameAction.java
@@ -19,11 +19,19 @@ public sealed interface GameAction {
             Set<UUID> players
     ) implements GameAction {
 
+        public ToHub {
+            players = players == null ? Set.of() : Set.copyOf(players);
+        }
+
     }
 
     record EnterGame(
             Set<UUID> players
     ) implements GameAction {
+
+        public EnterGame {
+            players = players == null ? Set.of() : Set.copyOf(players);
+        }
 
     }
 
@@ -32,11 +40,30 @@ public sealed interface GameAction {
             @Nullable Location where
     ) implements GameAction {
 
+        public ToSpectate {
+            players = players == null ? Set.of() : Set.copyOf(players);
+        }
+
+    }
+
+    record EndGame(
+            String reason
+    ) implements GameAction {
+
     }
 
     record EndGameAndBackToHub(
+            Set<UUID> players,
             String reason
     ) implements GameAction {
+
+        public EndGameAndBackToHub(String reason) {
+            this(Set.of(), reason);
+        }
+
+        public EndGameAndBackToHub {
+            players = players == null ? Set.of() : Set.copyOf(players);
+        }
 
     }
 

--- a/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/flow/decision/JoinDecision.java
+++ b/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/flow/decision/JoinDecision.java
@@ -5,7 +5,17 @@ import org.jspecify.annotations.Nullable;
 
 public sealed interface JoinDecision {
 
+    /**
+     * Keep the player in the generic hub without attaching them to the active game session.
+     */
     record ToHub() implements JoinDecision {
+
+    }
+
+    /**
+     * Keep the player in the generic hub, but attach them to the active session as mode-owned audience/waiting data.
+     */
+    record AttachToHub() implements JoinDecision {
 
     }
 

--- a/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlow.java
+++ b/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlow.java
@@ -1,6 +1,7 @@
 package top.ourisland.creepersiarena.api.game.mode;
 
 import org.bukkit.Location;
+import org.bukkit.inventory.PlayerInventory;
 import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
 import top.ourisland.creepersiarena.api.game.mode.context.ModePlayerContext;
 
@@ -46,31 +47,33 @@ public interface IModePlayerFlow {
     }
 
     /**
-     * Returns how many teams this mode allows players to select from in the generic lobby UI.
+     * Returns whether the hub entrance region may trigger this mode's join flow.
      * <p>
-     * Returning {@code 0} hides the core-provided team selector. Modes with custom lobby/team selection flows can keep
-     * this disabled and expose their own controls through their extension.
+     * Entrance semantics are mode-owned because some modes, such as always-open battle arenas, treat the entrance as a
+     * direct join, while round-based modes may expose only a ready/waiting UI in the hub.
      *
      * @param ctx lobby context
      *
-     * @return selectable team count; {@code 0} means no generic team selector
+     * @return {@code true} when the generic lobby entrance listener may request a join for this mode
      */
-    default int selectableTeamCount(ModeLobbyContext ctx) {
-        return 0;
+    default boolean allowHubEntrance(ModeLobbyContext ctx) {
+        return false;
     }
 
     /**
-     * Returns whether job-selector items and job-selection commands are accepted right now.
+     * Returns whether the generic lobby listener should protect and route lobby inventory input for this player.
      * <p>
-     * Implementations usually return the same value as {@link #showJobSelector(ModeLobbyContext)}. The method is
-     * separate so a mode can render a read-only selector or accept a command while rendering the UI elsewhere.
+     * Modes with custom lobby items can override this without exposing their item semantics to core. The default keeps
+     * the previous core behaviour for lobby states and enabled core selectors.
      *
      * @param ctx lobby/player context
      *
-     * @return {@code true} when a job selection may update the player's selected job
+     * @return {@code true} when core should cancel and route lobby inventory interactions
      */
-    default boolean allowJobSelection(ModeLobbyContext ctx) {
-        return showJobSelector(ctx);
+    default boolean acceptsLobbyUiInput(ModeLobbyContext ctx) {
+        return ctx != null
+                && ctx.session() != null
+                && (ctx.session().state().isLobbyState() || showJobSelector(ctx) || selectableTeamCount(ctx) > 0);
     }
 
     /**
@@ -86,6 +89,46 @@ public interface IModePlayerFlow {
      */
     default boolean showJobSelector(ModeLobbyContext ctx) {
         return ctx != null && ctx.session() != null && ctx.session().state().isLobbyState();
+    }
+
+    /**
+     * Returns how many teams this mode allows players to select from in the generic lobby UI.
+     * <p>
+     * Returning {@code 0} hides the core-provided team selector. Modes with custom lobby/team selection flows can keep
+     * this disabled and expose their own controls through their extension.
+     *
+     * @param ctx lobby context
+     *
+     * @return selectable team count; {@code 0} means no generic team selector
+     */
+    default int selectableTeamCount(ModeLobbyContext ctx) {
+        return 0;
+    }
+
+    /**
+     * Lets a mode decorate the already-created generic lobby inventory with mode-owned controls.
+     * <p>
+     * Core still owns clearing/protecting the inventory and rendering generic selectors. Mode-specific ready buttons,
+     * phase controls, or read-only indicators belong in the active mode and can be installed here.
+     *
+     * @param ctx       lobby/player context
+     * @param inventory player inventory after generic core items have been applied
+     */
+    default void decorateLobbyInventory(ModeLobbyContext ctx, PlayerInventory inventory) {
+    }
+
+    /**
+     * Returns whether job-selector items and job-selection commands are accepted right now.
+     * <p>
+     * Implementations usually return the same value as {@link #showJobSelector(ModeLobbyContext)}. The method is
+     * separate so a mode can render a read-only selector or accept a command while rendering the UI elsewhere.
+     *
+     * @param ctx lobby/player context
+     *
+     * @return {@code true} when a job selection may update the player's selected job
+     */
+    default boolean allowJobSelection(ModeLobbyContext ctx) {
+        return showJobSelector(ctx);
     }
 
     /**

--- a/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlow.java
+++ b/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlow.java
@@ -60,6 +60,35 @@ public interface IModePlayerFlow {
     }
 
     /**
+     * Returns whether job-selector items and job-selection commands are accepted right now.
+     * <p>
+     * Implementations usually return the same value as {@link #showJobSelector(ModeLobbyContext)}. The method is
+     * separate so a mode can render a read-only selector or accept a command while rendering the UI elsewhere.
+     *
+     * @param ctx lobby/player context
+     *
+     * @return {@code true} when a job selection may update the player's selected job
+     */
+    default boolean allowJobSelection(ModeLobbyContext ctx) {
+        return showJobSelector(ctx);
+    }
+
+    /**
+     * Returns whether the core-provided job selector should be shown for the supplied player state.
+     * <p>
+     * The default preserves the historical behaviour: jobs can be picked in normal lobby states. Modes with their own
+     * round flow can move this UI into a mode phase, for example a pre-round job-selection phase, and keep HUB/RESPAWN
+     * inventories clean.
+     *
+     * @param ctx lobby/player context
+     *
+     * @return {@code true} when core should render job-selection items for this player
+     */
+    default boolean showJobSelector(ModeLobbyContext ctx) {
+        return ctx != null && ctx.session() != null && ctx.session().state().isLobbyState();
+    }
+
+    /**
      * Applies mode-specific player state after core has moved the player into the generic in-game stage.
      * <p>
      * Typical implementations equip a loadout, update mode-local session data, show mode-specific UI, or set the Bukkit

--- a/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlow.java
+++ b/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlow.java
@@ -132,6 +132,21 @@ public interface IModePlayerFlow {
     }
 
     /**
+     * Returns whether the shared job/skill runtime may render and tick gameplay skill items for this player right now.
+     * <p>
+     * Some modes move players into the generic {@code IN_GAME} stage for pre-round UI such as job selection. Those
+     * phases should not receive loadout skill items, otherwise mode-owned selector items can be overwritten by the
+     * global skill hotbar renderer. The default preserves historical behaviour for always-live combat modes.
+     *
+     * @param ctx player-flow context
+     *
+     * @return {@code true} when core skill ticking and hotbar rendering are allowed
+     */
+    default boolean allowGameplaySkillRuntime(ModePlayerContext ctx) {
+        return true;
+    }
+
+    /**
      * Applies mode-specific player state after core has moved the player into the generic in-game stage.
      * <p>
      * Typical implementations equip a loadout, update mode-local session data, show mode-specific UI, or set the Bukkit

--- a/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/IModeTimeline.java
+++ b/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/IModeTimeline.java
@@ -48,4 +48,15 @@ public interface IModeTimeline {
      */
     List<GameAction> tick(TickContext ctx);
 
+    /**
+     * Releases mode-owned runtime UI or temporary state when this timeline is no longer active.
+     * <p>
+     * Core calls this before replacing or ending the active game. Implementations should keep this method cheap and
+     * idempotent; it is primarily intended for side-effect-only resources such as bossbars.
+     *
+     * @param ctx final context for the game session that is being stopped
+     */
+    default void onStop(TickContext ctx) {
+    }
+
 }

--- a/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/context/JoinContext.java
+++ b/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/context/JoinContext.java
@@ -23,7 +23,7 @@ public record JoinContext(
     }
 
     public boolean fromHubRequest() {
-        return source == JoinSource.HUB_REQUEST;
+        return source == JoinSource.HUB_REQUEST || source == JoinSource.HUB_ENTRANCE;
     }
 
 }

--- a/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/context/JoinSource.java
+++ b/cia-api/src/main/java/top/ourisland/creepersiarena/api/game/mode/context/JoinSource.java
@@ -3,6 +3,7 @@ package top.ourisland.creepersiarena.api.game.mode.context;
 public enum JoinSource {
 
     SERVER_JOIN,
-    HUB_REQUEST
+    HUB_REQUEST,
+    HUB_ENTRANCE
 
 }

--- a/cia-api/src/test/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlowTest.java
+++ b/cia-api/src/test/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlowTest.java
@@ -2,6 +2,7 @@ package top.ourisland.creepersiarena.api.game.mode;
 
 import org.junit.jupiter.api.Test;
 import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
+import top.ourisland.creepersiarena.api.game.mode.context.ModePlayerContext;
 import top.ourisland.creepersiarena.api.game.player.PlayerSession;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
 
@@ -28,6 +29,9 @@ class IModePlayerFlowTest {
         assertFalse(IModePlayerFlow.DEFAULT.showJobSelector(ctx));
         assertFalse(IModePlayerFlow.DEFAULT.allowJobSelection(ctx));
         assertFalse(IModePlayerFlow.DEFAULT.acceptsLobbyUiInput(ctx));
+        assertTrue(IModePlayerFlow.DEFAULT.allowGameplaySkillRuntime(
+                new ModePlayerContext(null, null, null, session, null)
+        ));
     }
 
 }

--- a/cia-api/src/test/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlowTest.java
+++ b/cia-api/src/test/java/top/ourisland/creepersiarena/api/game/mode/IModePlayerFlowTest.java
@@ -1,0 +1,33 @@
+package top.ourisland.creepersiarena.api.game.mode;
+
+import org.junit.jupiter.api.Test;
+import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
+import top.ourisland.creepersiarena.api.game.player.PlayerState;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static top.ourisland.creepersiarena.api.testsupport.TestBukkit.player;
+
+class IModePlayerFlowTest {
+
+    @Test
+    void defaultFlowKeepsEntranceDisabledAndAcceptsOnlyLobbyUiStates() {
+        var session = new PlayerSession(player(UUID.randomUUID()));
+        var ctx = new ModeLobbyContext(null, null, session);
+
+        assertFalse(IModePlayerFlow.DEFAULT.allowHubEntrance(ctx));
+        assertTrue(IModePlayerFlow.DEFAULT.showJobSelector(ctx));
+        assertTrue(IModePlayerFlow.DEFAULT.allowJobSelection(ctx));
+        assertTrue(IModePlayerFlow.DEFAULT.acceptsLobbyUiInput(ctx));
+
+        session.state(PlayerState.IN_GAME);
+
+        assertFalse(IModePlayerFlow.DEFAULT.showJobSelector(ctx));
+        assertFalse(IModePlayerFlow.DEFAULT.allowJobSelection(ctx));
+        assertFalse(IModePlayerFlow.DEFAULT.acceptsLobbyUiInput(ctx));
+    }
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/core/bootstrap/module/SkillModule.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/core/bootstrap/module/SkillModule.java
@@ -11,6 +11,7 @@ import top.ourisland.creepersiarena.core.bootstrap.ListenerBinder;
 import top.ourisland.creepersiarena.core.bootstrap.StageTask;
 import top.ourisland.creepersiarena.core.component.annotation.CiaBootstrapModule;
 import top.ourisland.creepersiarena.core.component.discovery.ComponentCatalog;
+import top.ourisland.creepersiarena.game.GameManager;
 import top.ourisland.creepersiarena.job.listener.SkillUiListener;
 import top.ourisland.creepersiarena.job.skill.SkillTickTask;
 import top.ourisland.creepersiarena.job.skill.runtime.InMemorySkillStateStore;
@@ -54,12 +55,12 @@ public final class SkillModule implements IBootstrapModule {
             var skillRenderer = new SkillHotbarRenderer(skillCodec, skillStore);
             var tickTask = new SkillTickTask(
                     sessionStore,
+                    () -> rt.getService(GameManager.class),
                     skillRegistry,
                     skillRuntime,
                     rt.plugin(),
                     skillRenderer
             );
-
 
             rt.putAllServices(Map.of(
                     SkillItemCodec.class, skillCodec,

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/GameManager.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/GameManager.java
@@ -79,6 +79,8 @@ public final class GameManager {
         var rt = runtime();
         var mode = Objects.requireNonNull(modes.get(type), "Mode not registered: " + type).value();
 
+        stopActiveTimeline("replace active game");
+
         var session = new GameSession(type, arena);
         var logic = mode.createLogic(session, rt);
 
@@ -94,6 +96,20 @@ public final class GameManager {
                 (rules == null ? "null" : rules.getClass().getSimpleName()),
                 (timeline == null ? "null" : timeline.getClass().getSimpleName())
         );
+    }
+
+    private void stopActiveTimeline(String reason) {
+        if (active == null || timeline == null || runtime == null) return;
+        try {
+            timeline.onStop(new TickContext(runtime, active));
+        } catch (Throwable t) {
+            logger.warn("[Game] timeline stop failed: mode={} arena={} reason={}",
+                    active.mode(),
+                    active.arena().id(),
+                    reason,
+                    t
+            );
+        }
     }
 
     public boolean rotateActive(String reason) {
@@ -128,6 +144,7 @@ public final class GameManager {
     public void endActive() {
         if (active == null) return;
         logger.info("[Game] endActive: mode={} arena={}", active.mode(), active.arena().id());
+        stopActiveTimeline("end active game");
         active = null;
         rules = null;
         timeline = null;

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/GameManager.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/GameManager.java
@@ -65,6 +65,45 @@ public final class GameManager {
                 .getSimpleName());
     }
 
+    public void start(GameModeType type, String arenaId) {
+        var arena = arenaManager.getArena(arenaId);
+        if (arena == null) throw new IllegalArgumentException("Arena not found: " + arenaId);
+        if (!arena.type().equals(type)) throw new IllegalArgumentException("Arena type mismatch: " + arenaId);
+
+        logger.info("[Game] Start requested: mode={} arenaId={}", type, arenaId);
+
+        startWithArena(type, arena);
+    }
+
+    private void startWithArena(GameModeType type, ArenaInstance arena) {
+        var rt = runtime();
+        var mode = Objects.requireNonNull(modes.get(type), "Mode not registered: " + type).value();
+
+        var session = new GameSession(type, arena);
+        var logic = mode.createLogic(session, rt);
+
+        this.active = session;
+        this.rules = logic.rules();
+        this.timeline = logic.timeline();
+        this.playerFlow = logic.playerFlow();
+        this.lastAutoArenaId.put(type, arena.id());
+
+        logger.info("[Game] Started: mode={} arena={} rules={} timeline={}",
+                type,
+                arena.id(),
+                (rules == null ? "null" : rules.getClass().getSimpleName()),
+                (timeline == null ? "null" : timeline.getClass().getSimpleName())
+        );
+    }
+
+    public boolean rotateActive(String reason) {
+        if (active == null) return false;
+        GameModeType type = active.mode();
+        logger.info("[Game] rotateActive: mode={} arena={} reason={}", type, active.arena().id(), reason);
+        startAuto(type);
+        return true;
+    }
+
     public void startAuto(GameModeType type) {
         List<ArenaInstance> list = arenaManager.arenasOf(type);
         if (list.isEmpty()) throw new IllegalStateException("No arena for mode: " + type);
@@ -84,36 +123,6 @@ public final class GameManager {
         logger.info("[Game] startAuto picked arena: mode={} arena={} (candidates={})", type, picked.id(), n);
 
         startWithArena(type, picked);
-    }
-
-    private void startWithArena(GameModeType type, ArenaInstance arena) {
-        var rt = runtime();
-        var mode = Objects.requireNonNull(modes.get(type), "Mode not registered: " + type).value();
-
-        var session = new GameSession(type, arena);
-        var logic = mode.createLogic(session, rt);
-
-        this.active = session;
-        this.rules = logic.rules();
-        this.timeline = logic.timeline();
-        this.playerFlow = logic.playerFlow();
-
-        logger.info("[Game] Started: mode={} arena={} rules={} timeline={}",
-                type,
-                arena.id(),
-                (rules == null ? "null" : rules.getClass().getSimpleName()),
-                (timeline == null ? "null" : timeline.getClass().getSimpleName())
-        );
-    }
-
-    public void start(GameModeType type, String arenaId) {
-        var arena = arenaManager.getArena(arenaId);
-        if (arena == null) throw new IllegalArgumentException("Arena not found: " + arenaId);
-        if (!arena.type().equals(type)) throw new IllegalArgumentException("Arena type mismatch: " + arenaId);
-
-        logger.info("[Game] Start requested: mode={} arenaId={}", type, arenaId);
-
-        startWithArena(type, arena);
     }
 
     public void endActive() {

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/GameFlow.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/GameFlow.java
@@ -553,6 +553,11 @@ public final class GameFlow {
                 log.info("[Flow] end game: reason={}", reason);
             }
 
+            case GameAction.RotateArena(String reason) -> {
+                boolean rotated = gameManager.rotateActive(reason);
+                log.info("[Flow] rotate active arena: reason={} rotated={}", reason, rotated);
+            }
+
             case GameAction.EndGameAndBackToHub(Set<UUID> requestedPlayers, String reason) -> {
                 var ended = gameManager.active();
                 Set<UUID> players = requestedPlayers == null || requestedPlayers.isEmpty()

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/GameFlow.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/GameFlow.java
@@ -194,24 +194,42 @@ public final class GameFlow {
         log.debug("[Flow] player left, session removed: name={} reason={}", p.getName(), reason);
     }
 
-    private void detachFromActiveGame(Player p, PlayerSession s, LeaveReason reason) {
-        GameSession g = gameManager.active();
-        if (g != null) {
-            boolean attached = g.players().contains(p.getUniqueId());
-            if (attached) {
-                g.removePlayer(p.getUniqueId());
+    private void detachFromActiveGame(
+            Player p,
+            PlayerSession s,
+            LeaveReason reason
+    ) {
+        detachFromGame(gameManager.active(), p, s, reason);
+    }
 
-                log.info("[Flow] player detached from gameSession: name={} mode={} arena={} reason={}",
-                        p.getName(), g.mode(), g.arena().id(), reason
-                );
+    private void detachFromGame(
+            GameSession g,
+            Player p,
+            PlayerSession s,
+            LeaveReason reason
+    ) {
+        if (p == null || g == null) {
+            if (p != null) {
+                respawns.cancel(p);
+                cancelPendingLeave(p);
+            }
+            return;
+        }
 
-                var rules = gameManager.rules();
-                if (rules != null && s != null) {
-                    try {
-                        rules.onLeave(new LeaveContext(gameManager.runtime(), g, p, s));
-                    } catch (Throwable t) {
-                        log.warn("[Flow] rules.onLeave failed: {}", t.getMessage(), t);
-                    }
+        boolean attached = g.players().contains(p.getUniqueId());
+        if (attached) {
+            g.removePlayer(p.getUniqueId());
+
+            log.info("[Flow] player detached from gameSession: name={} mode={} arena={} reason={}",
+                    p.getName(), g.mode(), g.arena().id(), reason
+            );
+
+            var rules = gameManager.rules();
+            if (rules != null && s != null) {
+                try {
+                    rules.onLeave(new LeaveContext(gameManager.runtime(), g, p, s));
+                } catch (Throwable t) {
+                    log.warn("[Flow] rules.onLeave failed: {}", t.getMessage(), t);
                 }
             }
         }
@@ -549,8 +567,17 @@ public final class GameFlow {
             }
 
             case GameAction.EndGame(String reason) -> {
+                var ended = gameManager.active();
+                Set<UUID> players = ended == null ? Set.of() : Set.copyOf(ended.players());
+
+                forEachOnline(players, p -> {
+                    cancelPendingLeave(p);
+                    respawns.cancel(p);
+                    detachFromGame(ended, p, store.get(p), LeaveReason.SYSTEM);
+                });
+
                 gameManager.endActive();
-                log.info("[Flow] end game: reason={}", reason);
+                log.info("[Flow] end game: reason={} players={}", reason, players.size());
             }
 
             case GameAction.RotateArena(String reason) -> {
@@ -564,15 +591,17 @@ public final class GameFlow {
                         ? ((ended == null) ? Set.of() : Set.copyOf(ended.players()))
                         : Set.copyOf(requestedPlayers);
 
-                gameManager.endActive();
-
                 log.info("[Flow] end game and back to hub: reason={} players={}", reason, players.size());
 
                 forEachOnline(players, p -> {
                     cancelPendingLeave(p);
                     respawns.cancel(p);
-                    transitions.toHub(p);
+                    detachFromGame(ended, p, store.get(p), LeaveReason.SYSTEM);
                 });
+
+                gameManager.endActive();
+
+                forEachOnline(players, transitions::toHub);
             }
         }
     }

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/GameFlow.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/GameFlow.java
@@ -214,7 +214,7 @@ public final class GameFlow {
         var s = store.get(p);
         if (s == null) return;
 
-        if (!s.state().isLobbyState()) return;
+        if (!transitions.acceptsLobbyUiInput(p)) return;
 
         log.debug("[Flow] lobbyAction: name={} state={} action={} page={} jobId={}",
                 p.getName(), s.state(), action, jobPage, jobId
@@ -249,15 +249,23 @@ public final class GameFlow {
     }
 
     /**
-     * Commands: select a job in HUB/RESPAWN.
+     * Commands: select a job when the active mode allows core job selection.
      */
     public boolean lobbySelectJob(Player p, String jobIdRaw) {
         if (p == null) return false;
         var s = store.get(p);
-        if (s == null || !s.state().isLobbyState()) return false;
+        if (s == null || !transitions.allowJobSelection(p)) return false;
 
         transitions.selectJob(p, jobIdRaw);
         return true;
+    }
+
+    /**
+     * Returns whether the current player state or active mode accepts core lobby/job-selector UI input.
+     */
+    public boolean acceptsLobbyUiInput(Player p) {
+        if (p == null) return false;
+        return transitions.acceptsLobbyUiInput(p);
     }
 
     /**
@@ -277,7 +285,7 @@ public final class GameFlow {
     public boolean refreshLobbyKit(Player p) {
         if (p == null) return false;
         PlayerSession s = store.get(p);
-        if (s == null || !s.state().isLobbyState()) return false;
+        if (s == null || !transitions.acceptsLobbyUiInput(p)) return false;
 
         transitions.refreshLobbyKit(p);
         return true;

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/GameFlow.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/GameFlow.java
@@ -12,10 +12,7 @@ import top.ourisland.creepersiarena.api.game.flow.decision.JoinDecision;
 import top.ourisland.creepersiarena.api.game.flow.decision.RespawnDecision;
 import top.ourisland.creepersiarena.api.game.mode.GameModeType;
 import top.ourisland.creepersiarena.api.game.mode.IModeRules;
-import top.ourisland.creepersiarena.api.game.mode.context.JoinContext;
-import top.ourisland.creepersiarena.api.game.mode.context.JoinSource;
-import top.ourisland.creepersiarena.api.game.mode.context.LeaveContext;
-import top.ourisland.creepersiarena.api.game.mode.context.RespawnContext;
+import top.ourisland.creepersiarena.api.game.mode.context.*;
 import top.ourisland.creepersiarena.api.game.player.PlayerSession;
 import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
@@ -110,8 +107,7 @@ public final class GameFlow {
         var rules = gameManager.rules();
 
         if (g != null) {
-            g.addPlayer(p.getUniqueId());
-            log.info("[Flow] player joined gameSession: name={} mode={} arena={}",
+            log.info("[Flow] player joined while game is active: name={} mode={} arena={}",
                     p.getName(), g.mode(), g.arena().id()
             );
 
@@ -145,20 +141,36 @@ public final class GameFlow {
 
         switch (decision) {
             case JoinDecision.ToHub _ -> transitions.toHub(p);
+            case JoinDecision.AttachToHub _ -> {
+                attachToActiveGame(p, g);
+                transitions.toHub(p);
+            }
             case JoinDecision.EnterGame _ -> {
                 if (g == null) {
                     transitions.toHub(p);
                 } else {
+                    attachToActiveGame(p, g);
                     transitions.enterGame(p, g, gameManager.runtime(), gameManager.playerFlow());
                 }
             }
             case JoinDecision.ToSpectate(Location where) -> {
+                attachToActiveGame(p, g);
                 Location loc = (where != null)
                         ? where
                         : (g != null ? g.arena().anchor().clone().add(0, 8, 0) : transitions.hubAnchor());
                 transitions.toSpectate(p, loc);
             }
         }
+    }
+
+    private void attachToActiveGame(Player p, GameSession g) {
+        if (p == null || g == null) return;
+        UUID id = p.getUniqueId();
+        if (g.players().contains(id)) return;
+        g.addPlayer(id);
+        log.info("[Flow] player attached to gameSession: name={} mode={} arena={}",
+                p.getName(), g.mode(), g.arena().id()
+        );
     }
 
     public void onPlayerLeaveServer(Player p, LeaveReason reason) {
@@ -185,18 +197,21 @@ public final class GameFlow {
     private void detachFromActiveGame(Player p, PlayerSession s, LeaveReason reason) {
         GameSession g = gameManager.active();
         if (g != null) {
-            g.removePlayer(p.getUniqueId());
+            boolean attached = g.players().contains(p.getUniqueId());
+            if (attached) {
+                g.removePlayer(p.getUniqueId());
 
-            log.info("[Flow] player detached from gameSession: name={} mode={} arena={} reason={}",
-                    p.getName(), g.mode(), g.arena().id(), reason
-            );
+                log.info("[Flow] player detached from gameSession: name={} mode={} arena={} reason={}",
+                        p.getName(), g.mode(), g.arena().id(), reason
+                );
 
-            var rules = gameManager.rules();
-            if (rules != null && s != null) {
-                try {
-                    rules.onLeave(new LeaveContext(gameManager.runtime(), g, p, s));
-                } catch (Throwable t) {
-                    log.warn("[Flow] rules.onLeave failed: {}", t.getMessage(), t);
+                var rules = gameManager.rules();
+                if (rules != null && s != null) {
+                    try {
+                        rules.onLeave(new LeaveContext(gameManager.runtime(), g, p, s));
+                    } catch (Throwable t) {
+                        log.warn("[Flow] rules.onLeave failed: {}", t.getMessage(), t);
+                    }
                 }
             }
         }
@@ -295,13 +310,31 @@ public final class GameFlow {
      * Legacy entry (called by LobbyEntryListener). Keep it for compatibility.
      */
     public void onHubEntryTriggered(Player p) {
-        requestJoinFromHub(p);
+        if (!allowsHubEntrance(p)) return;
+        requestJoinFromHub(p, JoinSource.HUB_ENTRANCE);
     }
 
-    /**
-     * /cia join or lobby entry trigger from HUB into the active game.
-     */
-    public JoinFromHubPlan requestJoinFromHub(Player p) {
+    public boolean allowsHubEntrance(Player p) {
+        if (p == null) return false;
+        PlayerSession session = store.get(p);
+        if (session == null || session.state() != PlayerState.HUB) return false;
+
+        GameSession active = gameManager.active();
+        var runtime = gameManager.runtime();
+        var playerFlow = gameManager.playerFlow();
+        if (active == null || runtime == null || playerFlow == null) return false;
+
+        try {
+            return playerFlow.allowHubEntrance(new ModeLobbyContext(runtime, p, session));
+        } catch (Throwable t) {
+            log.warn("[Flow] mode entrance hook failed: player={} mode={} err={}",
+                    p.getName(), active.mode(), t.getMessage(), t
+            );
+            return false;
+        }
+    }
+
+    private JoinFromHubPlan requestJoinFromHub(Player p, JoinSource source) {
         if (p == null) return new JoinFromHubPlan.NotPlayer();
 
         var s = store.get(p);
@@ -319,15 +352,20 @@ public final class GameFlow {
         cancelPendingLeave(p);
         respawns.cancel(p);
 
-        g.addPlayer(p.getUniqueId());
-
         var rules = gameManager.rules();
         var decision = rules == null
                 ? new JoinDecision.EnterGame()
-                : rules.onJoin(new JoinContext(gameManager.runtime(), g, p, s, JoinSource.HUB_REQUEST));
+                : rules.onJoin(new JoinContext(gameManager.runtime(), g, p, s, source));
         applyJoinDecision(p, g, decision);
 
         return new JoinFromHubPlan.Joined();
+    }
+
+    /**
+     * /cia join from HUB into the active game.
+     */
+    public JoinFromHubPlan requestJoinFromHub(Player p) {
+        return requestJoinFromHub(p, JoinSource.HUB_REQUEST);
     }
 
     public void onPlayerDeath(Player p) {
@@ -481,6 +519,7 @@ public final class GameFlow {
             case GameAction.ToHub(Set<UUID> players) -> forEachOnline(players, p -> {
                 cancelPendingLeave(p);
                 respawns.cancel(p);
+                detachFromActiveGame(p, store.get(p), LeaveReason.SYSTEM);
                 transitions.toHub(p);
             });
 
@@ -494,6 +533,7 @@ public final class GameFlow {
                 forEachOnline(players, p -> {
                     cancelPendingLeave(p);
                     respawns.cancel(p);
+                    attachToActiveGame(p, g);
                     transitions.enterGame(p, g, gameManager.runtime(), gameManager.playerFlow());
                 });
             }
@@ -503,17 +543,25 @@ public final class GameFlow {
                 forEachOnline(players, p -> {
                     cancelPendingLeave(p);
                     respawns.cancel(p);
+                    attachToActiveGame(p, gameManager.active());
                     transitions.toSpectate(p, loc);
                 });
             }
 
-            case GameAction.EndGameAndBackToHub(String reason) -> {
+            case GameAction.EndGame(String reason) -> {
+                gameManager.endActive();
+                log.info("[Flow] end game: reason={}", reason);
+            }
+
+            case GameAction.EndGameAndBackToHub(Set<UUID> requestedPlayers, String reason) -> {
                 var ended = gameManager.active();
-                Set<UUID> players = (ended == null) ? Set.of() : ended.players();
+                Set<UUID> players = requestedPlayers == null || requestedPlayers.isEmpty()
+                        ? ((ended == null) ? Set.of() : Set.copyOf(ended.players()))
+                        : Set.copyOf(requestedPlayers);
 
                 gameManager.endActive();
 
-                log.info("[Flow] end game and back to hub: reason={}", reason);
+                log.info("[Flow] end game and back to hub: reason={} players={}", reason, players.size());
 
                 forEachOnline(players, p -> {
                     cancelPendingLeave(p);

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/LeaveReason.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/LeaveReason.java
@@ -1,7 +1,10 @@
 package top.ourisland.creepersiarena.game.flow;
 
 public enum LeaveReason {
+
     QUIT,
     KICK,
-    COMMAND
+    COMMAND,
+    SYSTEM
+
 }

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerLobbyTransitions.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerLobbyTransitions.java
@@ -85,22 +85,34 @@ final class PlayerLobbyTransitions {
         var s = sessions.get(p);
         if (s == null) return;
 
+        boolean decorated = false;
         switch (s.state()) {
-            case HUB -> lobbyItemService.applyHubKit(
-                    p,
-                    s,
-                    cfg.get(),
-                    selectableTeamCount(p, s),
-                    showJobSelector(p, s)
-            );
-            case RESPAWN -> lobbyItemService.applyDeathKit(p, s, cfg.get(), showJobSelector(p, s));
+            case HUB -> {
+                lobbyItemService.applyHubKit(
+                        p,
+                        s,
+                        cfg.get(),
+                        selectableTeamCount(p, s),
+                        showJobSelector(p, s)
+                );
+                decorated = true;
+            }
+            case RESPAWN -> {
+                lobbyItemService.applyDeathKit(p, s, cfg.get(), showJobSelector(p, s));
+                decorated = true;
+            }
             case IN_GAME -> {
                 if (showJobSelector(p, s)) {
                     lobbyItemService.applyJobSelectionKit(p, s, cfg.get());
+                    decorated = true;
                 }
             }
             case null, default -> {
             }
+        }
+
+        if (decorated) {
+            decorateLobbyInventory(p, s);
         }
     }
 
@@ -128,10 +140,31 @@ final class PlayerLobbyTransitions {
         }
     }
 
+    private void decorateLobbyInventory(Player p, PlayerSession session) {
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return;
+        try {
+            flow.decorateLobbyInventory(new ModeLobbyContext(rt, p, session), p.getInventory());
+        } catch (Throwable t) {
+            log.warn("[Lobby] mode lobby-decoration failed: player={} err={}", p.getName(), t.getMessage(), t);
+        }
+    }
+
     boolean acceptsLobbyUiInput(Player p) {
         var s = sessions.get(p);
         if (s == null) return false;
-        return s.state().isLobbyState() || showJobSelector(p, s) || selectableTeamCount(p, s) > 0;
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) {
+            return s.state().isLobbyState() || showJobSelector(p, s) || selectableTeamCount(p, s) > 0;
+        }
+        try {
+            return flow.acceptsLobbyUiInput(new ModeLobbyContext(rt, p, s));
+        } catch (Throwable t) {
+            log.warn("[Lobby] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
+            return s.state().isLobbyState() || showJobSelector(p, s) || selectableTeamCount(p, s) > 0;
+        }
     }
 
     boolean allowJobSelection(Player p) {

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerLobbyTransitions.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerLobbyTransitions.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
 import top.ourisland.creepersiarena.api.game.mode.IModePlayerFlow;
 import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
 import top.ourisland.creepersiarena.api.job.JobId;
 import top.ourisland.creepersiarena.config.model.GlobalConfig;
@@ -44,7 +45,7 @@ final class PlayerLobbyTransitions {
 
     void selectJob(Player p, String jobIdRaw) {
         var s = sessions.ensureSession(p);
-        if (s.state() != PlayerState.HUB && s.state() != PlayerState.RESPAWN) return;
+        if (!allowJobSelection(p, s)) return;
 
         var jobId = JobId.fromId(jobIdRaw);
         if (jobId == null && jobIdRaw != null && jobIdRaw.indexOf(':') < 0) {
@@ -68,19 +69,42 @@ final class PlayerLobbyTransitions {
         log.info("[Lobby] {} selected job={}", p.getName(), jobId.id());
     }
 
+    private boolean allowJobSelection(Player p, PlayerSession session) {
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return session != null && session.state().isLobbyState();
+        try {
+            return flow.allowJobSelection(new ModeLobbyContext(rt, p, session));
+        } catch (Throwable t) {
+            log.warn("[Lobby] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
+            return session != null && session.state().isLobbyState();
+        }
+    }
+
     void refreshLobbyKit(Player p) {
         var s = sessions.get(p);
         if (s == null) return;
 
         switch (s.state()) {
-            case HUB -> lobbyItemService.applyHubKit(p, s, cfg.get(), selectableTeamCount(p, s));
-            case RESPAWN -> lobbyItemService.applyDeathKit(p, s, cfg.get());
+            case HUB -> lobbyItemService.applyHubKit(
+                    p,
+                    s,
+                    cfg.get(),
+                    selectableTeamCount(p, s),
+                    showJobSelector(p, s)
+            );
+            case RESPAWN -> lobbyItemService.applyDeathKit(p, s, cfg.get(), showJobSelector(p, s));
+            case IN_GAME -> {
+                if (showJobSelector(p, s)) {
+                    lobbyItemService.applyJobSelectionKit(p, s, cfg.get());
+                }
+            }
             case null, default -> {
             }
         }
     }
 
-    private int selectableTeamCount(Player p, top.ourisland.creepersiarena.api.game.player.PlayerSession session) {
+    private int selectableTeamCount(Player p, PlayerSession session) {
         GameRuntime rt = runtime.get();
         IModePlayerFlow flow = playerFlow.get();
         if (rt == null || flow == null) return 0;
@@ -92,9 +116,32 @@ final class PlayerLobbyTransitions {
         }
     }
 
+    private boolean showJobSelector(Player p, PlayerSession session) {
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return session != null && session.state().isLobbyState();
+        try {
+            return flow.showJobSelector(new ModeLobbyContext(rt, p, session));
+        } catch (Throwable t) {
+            log.warn("[Lobby] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
+            return session != null && session.state().isLobbyState();
+        }
+    }
+
+    boolean acceptsLobbyUiInput(Player p) {
+        var s = sessions.get(p);
+        if (s == null) return false;
+        return s.state().isLobbyState() || showJobSelector(p, s) || selectableTeamCount(p, s) > 0;
+    }
+
+    boolean allowJobSelection(Player p) {
+        var s = sessions.get(p);
+        return s != null && allowJobSelection(p, s);
+    }
+
     void nextJobPage(Player p) {
         var s = sessions.ensureSession(p);
-        if (s.state() != PlayerState.HUB && s.state() != PlayerState.RESPAWN) return;
+        if (!showJobSelector(p, s)) return;
 
         int per = Math.max(1, cfg.get().ui().lobby().jobsPerPage());
         int jobCount = lobbyItemService.totalJobs();

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerLobbyTransitions.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerLobbyTransitions.java
@@ -2,9 +2,6 @@ package top.ourisland.creepersiarena.game.flow;
 
 import org.bukkit.entity.Player;
 import org.slf4j.Logger;
-import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
-import top.ourisland.creepersiarena.api.game.mode.IModePlayerFlow;
-import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
 import top.ourisland.creepersiarena.api.game.player.PlayerSession;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
 import top.ourisland.creepersiarena.api.job.JobId;
@@ -24,23 +21,20 @@ final class PlayerLobbyTransitions {
     private final PlayerSessionFacade sessions;
     private final LobbyItemService lobbyItemService;
     private final Supplier<GlobalConfig> cfg;
-    private final Supplier<GameRuntime> runtime;
-    private final Supplier<IModePlayerFlow> playerFlow;
+    private final PlayerModeLobbyHooks lobbyHooks;
 
     PlayerLobbyTransitions(
             @lombok.NonNull Logger log,
             @lombok.NonNull PlayerSessionFacade sessions,
             @lombok.NonNull LobbyItemService lobbyItemService,
             @lombok.NonNull Supplier<GlobalConfig> cfg,
-            @lombok.NonNull Supplier<GameRuntime> runtime,
-            @lombok.NonNull Supplier<IModePlayerFlow> playerFlow
+            @lombok.NonNull PlayerModeLobbyHooks lobbyHooks
     ) {
         this.log = log;
         this.sessions = sessions;
         this.lobbyItemService = lobbyItemService;
         this.cfg = cfg;
-        this.runtime = runtime;
-        this.playerFlow = playerFlow;
+        this.lobbyHooks = lobbyHooks;
     }
 
     void selectJob(Player p, String jobIdRaw) {
@@ -70,15 +64,7 @@ final class PlayerLobbyTransitions {
     }
 
     private boolean allowJobSelection(Player p, PlayerSession session) {
-        GameRuntime rt = runtime.get();
-        IModePlayerFlow flow = playerFlow.get();
-        if (rt == null || flow == null) return session != null && session.state().isLobbyState();
-        try {
-            return flow.allowJobSelection(new ModeLobbyContext(rt, p, session));
-        } catch (Throwable t) {
-            log.warn("[Lobby] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
-            return session != null && session.state().isLobbyState();
-        }
+        return lobbyHooks.allowJobSelection(p, session);
     }
 
     void refreshLobbyKit(Player p) {
@@ -92,17 +78,17 @@ final class PlayerLobbyTransitions {
                         p,
                         s,
                         cfg.get(),
-                        selectableTeamCount(p, s),
-                        showJobSelector(p, s)
+                        lobbyHooks.selectableTeamCount(p, s),
+                        lobbyHooks.showJobSelector(p, s)
                 );
                 decorated = true;
             }
             case RESPAWN -> {
-                lobbyItemService.applyDeathKit(p, s, cfg.get(), showJobSelector(p, s));
+                lobbyItemService.applyDeathKit(p, s, cfg.get(), lobbyHooks.showJobSelector(p, s));
                 decorated = true;
             }
             case IN_GAME -> {
-                if (showJobSelector(p, s)) {
+                if (lobbyHooks.showJobSelector(p, s)) {
                     lobbyItemService.applyJobSelectionKit(p, s, cfg.get());
                     decorated = true;
                 }
@@ -112,59 +98,13 @@ final class PlayerLobbyTransitions {
         }
 
         if (decorated) {
-            decorateLobbyInventory(p, s);
-        }
-    }
-
-    private int selectableTeamCount(Player p, PlayerSession session) {
-        GameRuntime rt = runtime.get();
-        IModePlayerFlow flow = playerFlow.get();
-        if (rt == null || flow == null) return 0;
-        try {
-            return Math.max(0, flow.selectableTeamCount(new ModeLobbyContext(rt, p, session)));
-        } catch (Throwable t) {
-            log.warn("[Lobby] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
-            return 0;
-        }
-    }
-
-    private boolean showJobSelector(Player p, PlayerSession session) {
-        GameRuntime rt = runtime.get();
-        IModePlayerFlow flow = playerFlow.get();
-        if (rt == null || flow == null) return session != null && session.state().isLobbyState();
-        try {
-            return flow.showJobSelector(new ModeLobbyContext(rt, p, session));
-        } catch (Throwable t) {
-            log.warn("[Lobby] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
-            return session != null && session.state().isLobbyState();
-        }
-    }
-
-    private void decorateLobbyInventory(Player p, PlayerSession session) {
-        GameRuntime rt = runtime.get();
-        IModePlayerFlow flow = playerFlow.get();
-        if (rt == null || flow == null) return;
-        try {
-            flow.decorateLobbyInventory(new ModeLobbyContext(rt, p, session), p.getInventory());
-        } catch (Throwable t) {
-            log.warn("[Lobby] mode lobby-decoration failed: player={} err={}", p.getName(), t.getMessage(), t);
+            lobbyHooks.decorateLobbyInventory(p, s, p.getInventory());
         }
     }
 
     boolean acceptsLobbyUiInput(Player p) {
         var s = sessions.get(p);
-        if (s == null) return false;
-        GameRuntime rt = runtime.get();
-        IModePlayerFlow flow = playerFlow.get();
-        if (rt == null || flow == null) {
-            return s.state().isLobbyState() || showJobSelector(p, s) || selectableTeamCount(p, s) > 0;
-        }
-        try {
-            return flow.acceptsLobbyUiInput(new ModeLobbyContext(rt, p, s));
-        } catch (Throwable t) {
-            log.warn("[Lobby] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
-            return s.state().isLobbyState() || showJobSelector(p, s) || selectableTeamCount(p, s) > 0;
-        }
+        return lobbyHooks.acceptsLobbyUiInput(p, s);
     }
 
     boolean allowJobSelection(Player p) {
@@ -174,7 +114,7 @@ final class PlayerLobbyTransitions {
 
     void nextJobPage(Player p) {
         var s = sessions.ensureSession(p);
-        if (!showJobSelector(p, s)) return;
+        if (!lobbyHooks.showJobSelector(p, s)) return;
 
         int per = Math.max(1, cfg.get().ui().lobby().jobsPerPage());
         int jobCount = lobbyItemService.totalJobs();
@@ -191,7 +131,7 @@ final class PlayerLobbyTransitions {
 
     void cycleTeam(Player p) {
         var s = sessions.ensureSession(p);
-        int max = selectableTeamCount(p, s);
+        int max = lobbyHooks.selectableTeamCount(p, s);
         if (max <= 0) return;
 
         Integer cur = s.selectedTeam();
@@ -202,7 +142,7 @@ final class PlayerLobbyTransitions {
         var s = sessions.ensureSession(p);
         if (s.state() != PlayerState.HUB) return false;
 
-        int max = selectableTeamCount(p, s);
+        int max = lobbyHooks.selectableTeamCount(p, s);
         if (max <= 0) return false;
 
         Integer next = (teamId == null) ? null : Math.clamp(teamId, 1, max);

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerModeLobbyHooks.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerModeLobbyHooks.java
@@ -1,0 +1,115 @@
+package top.ourisland.creepersiarena.game.flow;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.PlayerInventory;
+import org.slf4j.Logger;
+import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
+import top.ourisland.creepersiarena.api.game.mode.IModePlayerFlow;
+import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
+
+import java.util.function.Supplier;
+
+/**
+ * Centralized access to mode-owned lobby/player-flow decisions.
+ * <p>
+ * Stage transitions and lobby transitions both call through this helper so hub, respawn, and in-game UI paths cannot
+ * silently drift apart.
+ */
+final class PlayerModeLobbyHooks {
+
+    private final Logger log;
+    private final Supplier<GameRuntime> runtime;
+    private final Supplier<IModePlayerFlow> playerFlow;
+
+    PlayerModeLobbyHooks(
+            @lombok.NonNull Logger log,
+            @lombok.NonNull Supplier<GameRuntime> runtime,
+            @lombok.NonNull Supplier<IModePlayerFlow> playerFlow
+    ) {
+        this.log = log;
+        this.runtime = runtime;
+        this.playerFlow = playerFlow;
+    }
+
+    boolean allowJobSelection(Player player, PlayerSession session) {
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return session != null && session.state().isLobbyState();
+        try {
+            return flow.allowJobSelection(new ModeLobbyContext(rt, player, session));
+        } catch (Throwable t) {
+            log.warn("[LobbyHooks] mode job-selection hook failed: player={} err={}",
+                    playerName(player), t.getMessage(), t
+            );
+            return session != null && session.state().isLobbyState();
+        }
+    }
+
+    private String playerName(Player player) {
+        return player == null ? "null" : player.getName();
+    }
+
+    boolean acceptsLobbyUiInput(Player player, PlayerSession session) {
+        if (session == null) return false;
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return defaultAcceptsLobbyUiInput(player, session);
+        try {
+            return flow.acceptsLobbyUiInput(new ModeLobbyContext(rt, player, session));
+        } catch (Throwable t) {
+            log.warn("[LobbyHooks] mode lobby-input hook failed: player={} err={}",
+                    playerName(player), t.getMessage(), t
+            );
+            return defaultAcceptsLobbyUiInput(player, session);
+        }
+    }
+
+    private boolean defaultAcceptsLobbyUiInput(Player player, PlayerSession session) {
+        return session.state()
+                .isLobbyState() || showJobSelector(player, session) || selectableTeamCount(player, session) > 0;
+    }
+
+    boolean showJobSelector(Player player, PlayerSession session) {
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return session != null && session.state().isLobbyState();
+        try {
+            return flow.showJobSelector(new ModeLobbyContext(rt, player, session));
+        } catch (Throwable t) {
+            log.warn("[LobbyHooks] mode job-selector hook failed: player={} err={}",
+                    playerName(player), t.getMessage(), t
+            );
+            return session != null && session.state().isLobbyState();
+        }
+    }
+
+    int selectableTeamCount(Player player, PlayerSession session) {
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return 0;
+        try {
+            return Math.max(0, flow.selectableTeamCount(new ModeLobbyContext(rt, player, session)));
+        } catch (Throwable t) {
+            log.warn("[LobbyHooks] mode selectable-team hook failed: player={} err={}",
+                    playerName(player), t.getMessage(), t
+            );
+            return 0;
+        }
+    }
+
+    void decorateLobbyInventory(Player player, PlayerSession session, PlayerInventory inventory) {
+        if (inventory == null) return;
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return;
+        try {
+            flow.decorateLobbyInventory(new ModeLobbyContext(rt, player, session), inventory);
+        } catch (Throwable t) {
+            log.warn("[LobbyHooks] mode lobby-decoration hook failed: player={} err={}",
+                    playerName(player), t.getMessage(), t
+            );
+        }
+    }
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerStageTransitions.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerStageTransitions.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import top.ourisland.creepersiarena.api.game.GameSession;
 import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
 import top.ourisland.creepersiarena.api.game.mode.IModePlayerFlow;
-import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
 import top.ourisland.creepersiarena.api.game.mode.context.ModePlayerContext;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
 import top.ourisland.creepersiarena.config.model.GlobalConfig;
@@ -33,8 +32,7 @@ final class PlayerStageTransitions {
     private final LobbyItemService lobbyItemService;
     private final LobbyService lobbyService;
     private final Supplier<GlobalConfig> cfg;
-    private final Supplier<GameRuntime> runtime;
-    private final Supplier<IModePlayerFlow> playerFlow;
+    private final PlayerModeLobbyHooks lobbyHooks;
 
     PlayerStageTransitions(
             @lombok.NonNull Logger log,
@@ -42,16 +40,14 @@ final class PlayerStageTransitions {
             @lombok.NonNull LobbyItemService lobbyItemService,
             @lombok.NonNull LobbyService lobbyService,
             @lombok.NonNull Supplier<GlobalConfig> cfg,
-            @lombok.NonNull Supplier<GameRuntime> runtime,
-            @lombok.NonNull Supplier<IModePlayerFlow> playerFlow
+            @lombok.NonNull PlayerModeLobbyHooks lobbyHooks
     ) {
         this.log = log;
         this.sessions = sessions;
         this.lobbyItemService = lobbyItemService;
         this.lobbyService = lobbyService;
         this.cfg = cfg;
-        this.runtime = runtime;
-        this.playerFlow = playerFlow;
+        this.lobbyHooks = lobbyHooks;
     }
 
     void toHub(Player p) {
@@ -69,10 +65,10 @@ final class PlayerStageTransitions {
                 p,
                 session,
                 cfg.get(),
-                selectableTeamCount(p, session),
-                showJobSelector(p, session)
+                lobbyHooks.selectableTeamCount(p, session),
+                lobbyHooks.showJobSelector(p, session)
         );
-        decorateLobbyInventory(p, session);
+        lobbyHooks.decorateLobbyInventory(p, session, p.getInventory());
 
         log.debug("[Transitions] {} -> HUB (job={}, team={}, page={})",
                 p.getName(),
@@ -100,41 +96,6 @@ final class PlayerStageTransitions {
         });
     }
 
-    private int selectableTeamCount(Player p, top.ourisland.creepersiarena.api.game.player.PlayerSession session) {
-        GameRuntime rt = runtime.get();
-        IModePlayerFlow flow = playerFlow.get();
-        if (rt == null || flow == null) return 0;
-        try {
-            return Math.max(0, flow.selectableTeamCount(new ModeLobbyContext(rt, p, session)));
-        } catch (Throwable t) {
-            log.warn("[Transitions] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
-            return 0;
-        }
-    }
-
-    private boolean showJobSelector(Player p, top.ourisland.creepersiarena.api.game.player.PlayerSession session) {
-        GameRuntime rt = runtime.get();
-        IModePlayerFlow flow = playerFlow.get();
-        if (rt == null || flow == null) return session != null && session.state().isLobbyState();
-        try {
-            return flow.showJobSelector(new ModeLobbyContext(rt, p, session));
-        } catch (Throwable t) {
-            log.warn("[Transitions] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
-            return session != null && session.state().isLobbyState();
-        }
-    }
-
-    private void decorateLobbyInventory(Player p, top.ourisland.creepersiarena.api.game.player.PlayerSession session) {
-        GameRuntime rt = runtime.get();
-        IModePlayerFlow flow = playerFlow.get();
-        if (rt == null || flow == null) return;
-        try {
-            flow.decorateLobbyInventory(new ModeLobbyContext(rt, p, session), p.getInventory());
-        } catch (Throwable t) {
-            log.warn("[Transitions] mode lobby-decoration failed: player={} err={}", p.getName(), t.getMessage(), t);
-        }
-    }
-
     void toRespawnLobby(Player p, int seconds) {
         var session = sessions.ensureSession(p);
 
@@ -146,8 +107,8 @@ final class PlayerStageTransitions {
         Location to = deathAnchor();
         teleportAsync(p, to, "RESPAWN");
 
-        lobbyItemService.applyDeathKit(p, session, cfg.get(), showJobSelector(p, session));
-        decorateLobbyInventory(p, session);
+        lobbyItemService.applyDeathKit(p, session, cfg.get(), lobbyHooks.showJobSelector(p, session));
+        lobbyHooks.decorateLobbyInventory(p, session, p.getInventory());
 
         log.debug("[Transitions] {} -> RESPAWN ({}s)", p.getName(), seconds);
     }

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerStageTransitions.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerStageTransitions.java
@@ -65,7 +65,13 @@ final class PlayerStageTransitions {
         Location to = hubAnchor();
         teleportAsync(p, to, "HUB");
 
-        lobbyItemService.applyHubKit(p, session, cfg.get(), selectableTeamCount(p, session));
+        lobbyItemService.applyHubKit(
+                p,
+                session,
+                cfg.get(),
+                selectableTeamCount(p, session),
+                showJobSelector(p, session)
+        );
 
         log.debug("[Transitions] {} -> HUB (job={}, team={}, page={})",
                 p.getName(),
@@ -105,6 +111,18 @@ final class PlayerStageTransitions {
         }
     }
 
+    private boolean showJobSelector(Player p, top.ourisland.creepersiarena.api.game.player.PlayerSession session) {
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return session != null && session.state().isLobbyState();
+        try {
+            return flow.showJobSelector(new ModeLobbyContext(rt, p, session));
+        } catch (Throwable t) {
+            log.warn("[Transitions] mode lobby-flow failed: player={} err={}", p.getName(), t.getMessage(), t);
+            return session != null && session.state().isLobbyState();
+        }
+    }
+
     void toRespawnLobby(Player p, int seconds) {
         var session = sessions.ensureSession(p);
 
@@ -116,7 +134,7 @@ final class PlayerStageTransitions {
         Location to = deathAnchor();
         teleportAsync(p, to, "RESPAWN");
 
-        lobbyItemService.applyDeathKit(p, session, cfg.get());
+        lobbyItemService.applyDeathKit(p, session, cfg.get(), showJobSelector(p, session));
 
         log.debug("[Transitions] {} -> RESPAWN ({}s)", p.getName(), seconds);
     }

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerStageTransitions.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerStageTransitions.java
@@ -72,6 +72,7 @@ final class PlayerStageTransitions {
                 selectableTeamCount(p, session),
                 showJobSelector(p, session)
         );
+        decorateLobbyInventory(p, session);
 
         log.debug("[Transitions] {} -> HUB (job={}, team={}, page={})",
                 p.getName(),
@@ -123,6 +124,17 @@ final class PlayerStageTransitions {
         }
     }
 
+    private void decorateLobbyInventory(Player p, top.ourisland.creepersiarena.api.game.player.PlayerSession session) {
+        GameRuntime rt = runtime.get();
+        IModePlayerFlow flow = playerFlow.get();
+        if (rt == null || flow == null) return;
+        try {
+            flow.decorateLobbyInventory(new ModeLobbyContext(rt, p, session), p.getInventory());
+        } catch (Throwable t) {
+            log.warn("[Transitions] mode lobby-decoration failed: player={} err={}", p.getName(), t.getMessage(), t);
+        }
+    }
+
     void toRespawnLobby(Player p, int seconds) {
         var session = sessions.ensureSession(p);
 
@@ -135,6 +147,7 @@ final class PlayerStageTransitions {
         teleportAsync(p, to, "RESPAWN");
 
         lobbyItemService.applyDeathKit(p, session, cfg.get(), showJobSelector(p, session));
+        decorateLobbyInventory(p, session);
 
         log.debug("[Transitions] {} -> RESPAWN ({}s)", p.getName(), seconds);
     }

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerTransitions.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerTransitions.java
@@ -37,8 +37,9 @@ final class PlayerTransitions {
             @lombok.NonNull Supplier<IModePlayerFlow> playerFlow
     ) {
         this.sessions = new PlayerSessionFacade(plugin, log, store, lobbyItemService);
-        this.stage = new PlayerStageTransitions(log, sessions, lobbyItemService, lobbyService, cfg, runtime, playerFlow);
-        this.lobby = new PlayerLobbyTransitions(log, sessions, lobbyItemService, cfg, runtime, playerFlow);
+        var lobbyHooks = new PlayerModeLobbyHooks(log, runtime, playerFlow);
+        this.stage = new PlayerStageTransitions(log, sessions, lobbyItemService, lobbyService, cfg, lobbyHooks);
+        this.lobby = new PlayerLobbyTransitions(log, sessions, lobbyItemService, cfg, lobbyHooks);
     }
 
     PlayerSession getSession(Player p) {
@@ -57,7 +58,12 @@ final class PlayerTransitions {
         return stage.deathAnchor();
     }
 
-    Location gameSpawn(GameSession g, GameRuntime runtime, IModePlayerFlow playerFlow, Player p) {
+    Location gameSpawn(
+            GameSession g,
+            GameRuntime runtime,
+            IModePlayerFlow playerFlow,
+            Player p
+    ) {
         return stage.gameSpawn(g, runtime, playerFlow, p);
     }
 
@@ -77,7 +83,12 @@ final class PlayerTransitions {
         stage.toSpectate(p);
     }
 
-    void enterGame(Player p, GameSession g, GameRuntime runtime, IModePlayerFlow playerFlow) {
+    void enterGame(
+            Player p,
+            GameSession g,
+            GameRuntime runtime,
+            IModePlayerFlow playerFlow
+    ) {
         stage.enterGame(p, g, runtime, playerFlow);
     }
 

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerTransitions.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/flow/PlayerTransitions.java
@@ -85,6 +85,14 @@ final class PlayerTransitions {
         lobby.refreshLobbyKit(p);
     }
 
+    boolean acceptsLobbyUiInput(Player p) {
+        return lobby.acceptsLobbyUiInput(p);
+    }
+
+    boolean allowJobSelection(Player p) {
+        return lobby.allowJobSelection(p);
+    }
+
     void selectJob(Player p, String jobIdRaw) {
         lobby.selectJob(p, jobIdRaw);
     }

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/listener/LobbyEntryListener.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/listener/LobbyEntryListener.java
@@ -54,6 +54,11 @@ public final class LobbyEntryListener implements Listener {
             return;
         }
 
+        if (!flow.allowsHubEntrance(p)) {
+            cancel(p.getUniqueId());
+            return;
+        }
+
         EntryZone zone = lobbyService.entryZone("hub");
         if (zone == null || zone.timeMs() <= 0) {
             cancel(p.getUniqueId());
@@ -79,6 +84,7 @@ public final class LobbyEntryListener implements Listener {
 
             var ss = store.get(now);
             if (ss == null || ss.state() != PlayerState.HUB) return;
+            if (!flow.allowsHubEntrance(now)) return;
 
             EntryZone z2 = lobbyService.entryZone("hub");
             if (z2 == null || !z2.contains(now.getLocation())) return;

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/listener/LobbyUiListener.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/listener/LobbyUiListener.java
@@ -40,15 +40,19 @@ public final class LobbyUiListener implements Listener {
         if (!isClick) return;
 
         Player p = e.getPlayer();
-        var s = store.get(p);
-        if (s == null || !s.state().isLobbyState()) return;
+        if (store.get(p) == null) return;
 
         var item = e.getItem();
-        if (item == null) return;
+        if (!isLobbyUiItem(item)) return;
+        if (!flow.acceptsLobbyUiInput(p)) return;
 
         e.setCancelled(true);
-
         handleLobbyUiItem(p, item);
+    }
+
+    private boolean isLobbyUiItem(ItemStack item) {
+        if (item == null) return false;
+        return codec.readAction(item) != null || codec.readJobId(item) != null;
     }
 
     private void handleLobbyUiItem(Player p, ItemStack item) {
@@ -69,14 +73,13 @@ public final class LobbyUiListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onClick(InventoryClickEvent e) {
         if (!(e.getWhoClicked() instanceof Player p)) return;
-
-        var s = store.get(p);
-        if (s == null || !s.state().isLobbyState()) return;
+        if (store.get(p) == null) return;
+        if (!flow.acceptsLobbyUiInput(p)) return;
 
         e.setCancelled(true);
 
         var cur = e.getCurrentItem();
-        if (cur == null) return;
+        if (!isLobbyUiItem(cur)) return;
 
         handleLobbyUiItem(p, cur);
     }
@@ -84,9 +87,8 @@ public final class LobbyUiListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onDrag(InventoryDragEvent e) {
         if (!(e.getWhoClicked() instanceof Player p)) return;
-
-        var s = store.get(p);
-        if (s == null || !s.state().isLobbyState()) return;
+        if (store.get(p) == null) return;
+        if (!flow.acceptsLobbyUiInput(p)) return;
 
         e.setCancelled(true);
     }
@@ -95,13 +97,13 @@ public final class LobbyUiListener implements Listener {
     public void onSwap(PlayerSwapHandItemsEvent e) {
         Player p = e.getPlayer();
 
-        var s = store.get(p);
-        if (s == null || !s.state().isLobbyState()) return;
+        if (store.get(p) == null) return;
+        if (!flow.acceptsLobbyUiInput(p)) return;
 
         e.setCancelled(true);
 
         var mainHand = e.getMainHandItem();
-        if (!mainHand.getType().isAir()) handleLobbyUiItem(p, mainHand);
+        if (!mainHand.getType().isAir() && isLobbyUiItem(mainHand)) handleLobbyUiItem(p, mainHand);
     }
 
 }

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/lobby/item/LobbyItemService.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/lobby/item/LobbyItemService.java
@@ -25,13 +25,22 @@ public final class LobbyItemService {
             GlobalConfig cfg,
             int selectableTeamCount
     ) {
+        applyHubKit(p, s, cfg, selectableTeamCount, true);
+    }
+
+    public void applyHubKit(
+            Player p,
+            PlayerSession s,
+            GlobalConfig cfg,
+            int selectableTeamCount,
+            boolean showJobSelector
+    ) {
         clear(p);
 
         var inv = p.getInventory();
 
-        switch (cfg.ui().lobby().jobSelectMode()) {
-            case HOTBAR -> fillJobHotbar(inv, s, cfg);
-            case INVENTORY -> fillJobsInventory(inv, s, cfg);
+        if (showJobSelector) {
+            fillJobSelector(inv, s, cfg);
         }
 
         if (selectableTeamCount > 0) {
@@ -46,6 +55,17 @@ public final class LobbyItemService {
         inv.clear();
         inv.setArmorContents(null);
         inv.setItemInOffHand(null);
+    }
+
+    private void fillJobSelector(
+            PlayerInventory inv,
+            PlayerSession s,
+            GlobalConfig cfg
+    ) {
+        switch (cfg.ui().lobby().jobSelectMode()) {
+            case HOTBAR -> fillJobHotbar(inv, s, cfg);
+            case INVENTORY -> fillJobsInventory(inv, s, cfg);
+        }
     }
 
     private void fillJobHotbar(
@@ -98,16 +118,31 @@ public final class LobbyItemService {
             PlayerSession s,
             GlobalConfig cfg
     ) {
+        applyDeathKit(p, s, cfg, true);
+    }
+
+    public void applyDeathKit(
+            Player p,
+            PlayerSession s,
+            GlobalConfig cfg,
+            boolean showJobSelector
+    ) {
         clear(p);
 
-        var inv = p.getInventory();
-
-        switch (cfg.ui().lobby().jobSelectMode()) {
-            case HOTBAR -> fillJobHotbar(inv, s, cfg);
-            case INVENTORY -> fillJobsInventory(inv, s, cfg);
+        if (showJobSelector) {
+            fillJobSelector(p.getInventory(), s, cfg);
         }
 
-        inv.setItem(8, items.backToHubButton());
+        p.getInventory().setItem(8, items.backToHubButton());
+    }
+
+    public void applyJobSelectionKit(
+            Player p,
+            PlayerSession s,
+            GlobalConfig cfg
+    ) {
+        clear(p);
+        fillJobSelector(p.getInventory(), s, cfg);
     }
 
     public int totalJobs() {

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/job/skill/SkillTickTask.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/job/skill/SkillTickTask.java
@@ -2,20 +2,25 @@ package top.ourisland.creepersiarena.job.skill;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import top.ourisland.creepersiarena.api.game.mode.context.ModePlayerContext;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
 import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
 import top.ourisland.creepersiarena.api.skill.event.SkillContext;
 import top.ourisland.creepersiarena.api.skill.event.impl.TickEvent;
 import top.ourisland.creepersiarena.core.bootstrap.module.SkillModule;
+import top.ourisland.creepersiarena.game.GameManager;
 import top.ourisland.creepersiarena.job.skill.runtime.SkillRegistry;
 import top.ourisland.creepersiarena.job.skill.runtime.SkillRuntime;
 import top.ourisland.creepersiarena.job.skill.ui.SkillHotbarRenderer;
 
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 public final class SkillTickTask {
 
     private final PlayerSessionStore sessions;
+    private final Supplier<GameManager> gameManager;
     private final SkillRegistry registry;
     private final SkillRuntime runtime;
     private final org.bukkit.plugin.Plugin plugin;
@@ -25,12 +30,14 @@ public final class SkillTickTask {
 
     public SkillTickTask(
             PlayerSessionStore sessions,
+            Supplier<GameManager> gameManager,
             SkillRegistry registry,
             SkillRuntime runtime,
             org.bukkit.plugin.Plugin plugin,
             SkillHotbarRenderer renderer
     ) {
         this.sessions = sessions;
+        this.gameManager = gameManager;
         this.registry = registry;
         this.runtime = runtime;
         this.plugin = plugin;
@@ -52,6 +59,7 @@ public final class SkillTickTask {
         for (Player p : Bukkit.getOnlinePlayers()) {
             var s = sessions.get(p);
             if (s == null || s.state() != PlayerState.IN_GAME) continue;
+            if (!allowsGameplaySkills(p, s)) continue;
 
             runtime.handle(new SkillContext(
                     p,
@@ -64,6 +72,30 @@ public final class SkillTickTask {
             ));
 
             renderer.render(p, registry.skillsOf(p), now);
+        }
+    }
+
+    private boolean allowsGameplaySkills(Player player, PlayerSession session) {
+        GameManager manager = gameManager == null ? null : gameManager.get();
+        if (manager == null || manager.active() == null || manager.playerFlow() == null || manager.runtime() == null) {
+            return true;
+        }
+
+        if (!manager.active().players().contains(player.getUniqueId())) {
+            return false;
+        }
+
+        var ctx = new ModePlayerContext(
+                manager.runtime(),
+                manager.active(),
+                player,
+                session,
+                player.getLocation()
+        );
+        try {
+            return manager.playerFlow().allowGameplaySkillRuntime(ctx);
+        } catch (Throwable _) {
+            return false;
         }
     }
 

--- a/cia-core/src/test/java/top/ourisland/creepersiarena/game/flow/PlayerModeLobbyHooksTest.java
+++ b/cia-core/src/test/java/top/ourisland/creepersiarena/game/flow/PlayerModeLobbyHooksTest.java
@@ -1,0 +1,80 @@
+package top.ourisland.creepersiarena.game.flow;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
+import top.ourisland.creepersiarena.api.game.mode.IModePlayerFlow;
+import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
+import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
+import top.ourisland.creepersiarena.api.game.player.PlayerState;
+import top.ourisland.creepersiarena.api.testsupport.TestGameConfigViews;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static top.ourisland.creepersiarena.api.testsupport.TestBukkit.player;
+import static top.ourisland.creepersiarena.api.testsupport.TestGameConfigViews.empty;
+
+class PlayerModeLobbyHooksTest {
+
+    @Test
+    void routesEveryLobbyDecisionThroughOneModeFlow() {
+        var player = player(UUID.randomUUID());
+        var session = new PlayerSession(player);
+        var runtime = new GameRuntime(TestGameConfigViews::empty, new PlayerSessionStore());
+        int[] calls = new int[4];
+        var flow = new IModePlayerFlow() {
+            @Override
+            public boolean acceptsLobbyUiInput(ModeLobbyContext ctx) {
+                calls[3]++;
+                return false;
+            }
+
+            @Override
+            public boolean showJobSelector(ModeLobbyContext ctx) {
+                calls[0]++;
+                return false;
+            }
+
+            @Override
+            public int selectableTeamCount(ModeLobbyContext ctx) {
+                calls[1]++;
+                return 2;
+            }
+
+            @Override
+            public boolean allowJobSelection(ModeLobbyContext ctx) {
+                calls[2]++;
+                return true;
+            }
+        };
+        var hooks = new PlayerModeLobbyHooks(LoggerFactory.getLogger(getClass()), () -> runtime, () -> flow);
+
+        assertFalse(hooks.showJobSelector(player, session));
+        assertEquals(2, hooks.selectableTeamCount(player, session));
+        assertTrue(hooks.allowJobSelection(player, session));
+        assertFalse(hooks.acceptsLobbyUiInput(player, session));
+        assertArrayEquals(new int[]{1, 1, 1, 1}, calls);
+    }
+
+    @Test
+    void fallbackKeepsCoreLobbyStatesButDoesNotInventTeams() {
+        var player = player(UUID.randomUUID());
+        var session = new PlayerSession(player);
+        var hooks = new PlayerModeLobbyHooks(LoggerFactory.getLogger(getClass()), () -> null, () -> null);
+
+        assertTrue(hooks.showJobSelector(player, session));
+        assertTrue(hooks.allowJobSelection(player, session));
+        assertTrue(hooks.acceptsLobbyUiInput(player, session));
+        assertEquals(0, hooks.selectableTeamCount(player, session));
+
+        session.state(PlayerState.IN_GAME);
+
+        assertFalse(hooks.showJobSelector(player, session));
+        assertFalse(hooks.allowJobSelection(player, session));
+        assertFalse(hooks.acceptsLobbyUiInput(player, session));
+        assertEquals(0, hooks.selectableTeamCount(player, session));
+    }
+
+}

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/defaultcontent/DefaultContentExtension.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/defaultcontent/DefaultContentExtension.java
@@ -6,6 +6,7 @@ import top.ourisland.creepersiarena.api.extension.ICiaExtension;
 import top.ourisland.creepersiarena.api.extension.annotation.CiaExtensionInfo;
 import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
 import top.ourisland.creepersiarena.game.GameManager;
+import top.ourisland.creepersiarena.game.mode.impl.battle.BattleGameplayListener;
 import top.ourisland.creepersiarena.game.mode.impl.steal.runtime.StealGameplayListener;
 import top.ourisland.creepersiarena.job.listener.SkillImplementationListener;
 import top.ourisland.creepersiarena.job.skill.SkillTickTask;
@@ -48,6 +49,7 @@ public final class DefaultContentExtension implements ICiaExtension {
 
         BuiltinCombatUtils.installSessions(sessions);
         context.registerListener(new SkillImplementationListener(sessions, runtime, tickTask));
+        context.registerListener(new BattleGameplayListener(gameManager, sessions));
         context.registerListener(new StealGameplayListener(gameManager, sessions));
     }
 

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleBossBars.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleBossBars.java
@@ -1,0 +1,64 @@
+package top.ourisland.creepersiarena.game.mode.impl.battle;
+
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public final class BattleBossBars {
+
+    private final Set<UUID> viewers = new HashSet<>();
+    private BossBar mapProgress;
+
+    public void update(BattleState state) {
+        if (state == null) return;
+
+        Component title = Component.text("§cBattle §8| §e" + state.session().arena().id()
+                + " §8| §f" + state.mapProgress() + "§7/§f" + state.config().mapProgressTarget()
+                + " §8| §7" + state.scoreSummary());
+        float progress = state.progressRatio();
+
+        if (mapProgress == null) {
+            mapProgress = BossBar.bossBar(title, progress, BossBar.Color.RED, BossBar.Overlay.PROGRESS);
+        } else {
+            mapProgress.name(title);
+            mapProgress.progress(progress);
+        }
+
+        Set<UUID> desired = new HashSet<>();
+        for (UUID uuid : state.players()) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (state.isFighter(player)) {
+                desired.add(uuid);
+                player.showBossBar(mapProgress);
+            }
+        }
+
+        for (UUID uuid : Set.copyOf(viewers)) {
+            if (desired.contains(uuid)) continue;
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null && player.isOnline() && mapProgress != null) {
+                player.hideBossBar(mapProgress);
+            }
+            viewers.remove(uuid);
+        }
+        viewers.addAll(desired);
+    }
+
+    public void hide() {
+        if (mapProgress == null) return;
+        for (UUID uuid : Set.copyOf(viewers)) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null && player.isOnline()) {
+                player.hideBossBar(mapProgress);
+            }
+        }
+        viewers.clear();
+        mapProgress = null;
+    }
+
+}

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleBossBars.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleBossBars.java
@@ -2,6 +2,7 @@ package top.ourisland.creepersiarena.game.mode.impl.battle;
 
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -17,9 +18,15 @@ public final class BattleBossBars {
     public void update(BattleState state) {
         if (state == null) return;
 
-        Component title = Component.text("§cBattle §8| §e" + state.session().arena().id()
-                + " §8| §f" + state.mapProgress() + "§7/§f" + state.config().mapProgressTarget()
-                + " §8| §7" + state.scoreSummary());
+        Component title = Component.text("Battle", NamedTextColor.RED)
+                .append(separator())
+                .append(Component.text(state.session().arena().id(), NamedTextColor.YELLOW))
+                .append(separator())
+                .append(Component.text(state.mapProgress(), NamedTextColor.WHITE))
+                .append(Component.text("/", NamedTextColor.GRAY))
+                .append(Component.text(state.config().mapProgressTarget(), NamedTextColor.WHITE))
+                .append(separator())
+                .append(state.scoreSummaryComponent());
         float progress = state.progressRatio();
 
         if (mapProgress == null) {
@@ -47,6 +54,10 @@ public final class BattleBossBars {
             viewers.remove(uuid);
         }
         viewers.addAll(desired);
+    }
+
+    private Component separator() {
+        return Component.text(" | ", NamedTextColor.DARK_GRAY);
     }
 
     public void hide() {

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleGameplayListener.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleGameplayListener.java
@@ -1,5 +1,7 @@
 package top.ourisland.creepersiarena.game.mode.impl.battle;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
@@ -49,6 +51,29 @@ public final class BattleGameplayListener implements Listener {
         }
     }
 
+    private Player attackingPlayer(EntityDamageByEntityEvent event) {
+        if (event.getDamager() instanceof Player player) return player;
+        if (event.getDamager() instanceof Projectile projectile) {
+            ProjectileSource source = projectile.getShooter();
+            if (source instanceof Player player) return player;
+        }
+        return null;
+    }
+
+    private BattleState activeBattle() {
+        GameSession session = gameManager.active();
+        if (session == null || !session.mode().equals(BattleState.TYPE)) return null;
+        if (!(gameManager.timeline() instanceof BattleTimeline timeline)) return null;
+        return timeline.state();
+    }
+
+    private boolean sameTeam(PlayerSession left, PlayerSession right) {
+        if (left == null || right == null) return false;
+        Integer leftTeam = left.selectedTeam();
+        Integer rightTeam = right.selectedTeam();
+        return leftTeam != null && leftTeam.equals(rightTeam);
+    }
+
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
         BattleState state = activeBattle();
@@ -76,33 +101,11 @@ public final class BattleGameplayListener implements Listener {
 
         Player killer = victim.getKiller();
         if (state.recordKill(killer, victim)) {
-            killer.sendActionBar(net.kyori.adventure.text.Component.text(
-                    "§cBattle progress §f" + state.mapProgress() + "§7/§f" + state.config().mapProgressTarget()
-            ));
+            killer.sendActionBar(Component.text("Battle progress ", NamedTextColor.RED)
+                    .append(Component.text(state.mapProgress(), NamedTextColor.WHITE))
+                    .append(Component.text("/", NamedTextColor.GRAY))
+                    .append(Component.text(state.config().mapProgressTarget(), NamedTextColor.WHITE)));
         }
-    }
-
-    private BattleState activeBattle() {
-        GameSession session = gameManager.active();
-        if (session == null || !session.mode().equals(BattleState.TYPE)) return null;
-        if (!(gameManager.timeline() instanceof BattleTimeline timeline)) return null;
-        return timeline.state();
-    }
-
-    private Player attackingPlayer(EntityDamageByEntityEvent event) {
-        if (event.getDamager() instanceof Player player) return player;
-        if (event.getDamager() instanceof Projectile projectile) {
-            ProjectileSource source = projectile.getShooter();
-            if (source instanceof Player player) return player;
-        }
-        return null;
-    }
-
-    private boolean sameTeam(PlayerSession left, PlayerSession right) {
-        if (left == null || right == null) return false;
-        Integer leftTeam = left.selectedTeam();
-        Integer rightTeam = right.selectedTeam();
-        return leftTeam != null && leftTeam.equals(rightTeam);
     }
 
 }

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleGameplayListener.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleGameplayListener.java
@@ -1,0 +1,108 @@
+package top.ourisland.creepersiarena.game.mode.impl.battle;
+
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.projectiles.ProjectileSource;
+import top.ourisland.creepersiarena.api.game.GameSession;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
+import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
+import top.ourisland.creepersiarena.game.GameManager;
+
+public final class BattleGameplayListener implements Listener {
+
+    private final GameManager gameManager;
+    private final PlayerSessionStore sessions;
+
+    public BattleGameplayListener(GameManager gameManager, PlayerSessionStore sessions) {
+        this.gameManager = gameManager;
+        this.sessions = sessions;
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPvp(EntityDamageByEntityEvent event) {
+        if (!(event.getEntity() instanceof Player target)) return;
+        var attacker = attackingPlayer(event);
+        if (attacker == null) return;
+
+        BattleState state = activeBattle();
+        if (state == null) return;
+
+        boolean attackerFighter = state.isFighter(attacker);
+        boolean targetFighter = state.isFighter(target);
+        if (attackerFighter != targetFighter) {
+            event.setCancelled(true);
+            return;
+        }
+        if (!attackerFighter) return;
+
+        PlayerSession attackerSession = sessions.get(attacker);
+        PlayerSession targetSession = sessions.get(target);
+        if (sameTeam(attackerSession, targetSession)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        BattleState state = activeBattle();
+        if (state == null || !state.isFighter(event.getPlayer())) return;
+        event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        BattleState state = activeBattle();
+        if (state == null || !state.isFighter(event.getPlayer())) return;
+        event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onDeath(PlayerDeathEvent event) {
+        BattleState state = activeBattle();
+        if (state == null) return;
+
+        Player victim = event.getEntity();
+        if (!state.isFighter(victim)) return;
+
+        event.getDrops().clear();
+        event.setDroppedExp(0);
+
+        Player killer = victim.getKiller();
+        if (state.recordKill(killer, victim)) {
+            killer.sendActionBar(net.kyori.adventure.text.Component.text(
+                    "§cBattle progress §f" + state.mapProgress() + "§7/§f" + state.config().mapProgressTarget()
+            ));
+        }
+    }
+
+    private BattleState activeBattle() {
+        GameSession session = gameManager.active();
+        if (session == null || !session.mode().equals(BattleState.TYPE)) return null;
+        if (!(gameManager.timeline() instanceof BattleTimeline timeline)) return null;
+        return timeline.state();
+    }
+
+    private Player attackingPlayer(EntityDamageByEntityEvent event) {
+        if (event.getDamager() instanceof Player player) return player;
+        if (event.getDamager() instanceof Projectile projectile) {
+            ProjectileSource source = projectile.getShooter();
+            if (source instanceof Player player) return player;
+        }
+        return null;
+    }
+
+    private boolean sameTeam(PlayerSession left, PlayerSession right) {
+        if (left == null || right == null) return false;
+        Integer leftTeam = left.selectedTeam();
+        Integer rightTeam = right.selectedTeam();
+        return leftTeam != null && leftTeam.equals(rightTeam);
+    }
+
+}

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleMode.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleMode.java
@@ -5,16 +5,22 @@ import top.ourisland.creepersiarena.api.game.GameSession;
 import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
 import top.ourisland.creepersiarena.api.game.mode.IGameMode;
 import top.ourisland.creepersiarena.api.game.mode.ModeLogic;
+import top.ourisland.creepersiarena.game.mode.impl.battle.config.BattleModeConfig;
 
 @CiaModeDef(id = "battle")
 public final class BattleMode implements IGameMode {
 
     @Override
     public ModeLogic createLogic(GameSession session, GameRuntime runtime) {
+        BattleModeConfig config = BattleModeConfig.from(runtime.cfg());
+        BattleState state = new BattleState(runtime, session, config);
+        BattleTeamBalancer teams = new BattleTeamBalancer(config, runtime.sessionStore());
+        BattleBossBars bossBars = new BattleBossBars();
+
         return new ModeLogic(
-                new BattleRules(runtime, session),
-                new BattleTimeline(runtime, session),
-                new BattlePlayerFlow(runtime)
+                new BattleRules(state),
+                new BattleTimeline(state, bossBars),
+                new BattlePlayerFlow(runtime, state, teams)
         );
     }
 

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattlePlayerFlow.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattlePlayerFlow.java
@@ -11,7 +11,6 @@ import top.ourisland.creepersiarena.api.game.mode.IModePlayerFlow;
 import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
 import top.ourisland.creepersiarena.api.game.mode.context.ModePlayerContext;
 import top.ourisland.creepersiarena.defaultcontent.DefaultLoadoutService;
-import top.ourisland.creepersiarena.game.mode.impl.battle.config.BattleModeConfig;
 import top.ourisland.creepersiarena.job.JobManager;
 import top.ourisland.creepersiarena.job.skill.SkillTickTask;
 import top.ourisland.creepersiarena.job.skill.runtime.SkillRegistry;
@@ -30,9 +29,13 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public final class BattlePlayerFlow implements IModePlayerFlow {
 
+    private final BattleState state;
+    private final BattleTeamBalancer teams;
     private final DefaultLoadoutService kit;
 
-    public BattlePlayerFlow(GameRuntime runtime) {
+    public BattlePlayerFlow(GameRuntime runtime, BattleState state, BattleTeamBalancer teams) {
+        this.state = state;
+        this.teams = teams;
         this.kit = new DefaultLoadoutService(
                 runtime.requireService(JobManager.class),
                 runtime.requireService(SkillRegistry.class),
@@ -44,29 +47,38 @@ public final class BattlePlayerFlow implements IModePlayerFlow {
     @Override
     public Location spawnLocation(ModePlayerContext ctx) {
         ArenaInstance arena = ctx.game().arena();
-        List<Location> spawns = arena.spawnGroup("default");
-        if (spawns.isEmpty()) {
-            return arena.anchor();
+        var playerSession = ctx.session();
+        if (playerSession != null) {
+            teams.assign(playerSession, state.players());
         }
+        int team = playerSession == null || playerSession.selectedTeam() == null ? 0 : playerSession.selectedTeam();
+        List<Location> spawns = team <= 0 ? List.of() : arena.spawnGroup(String.valueOf(team));
+        if (spawns.isEmpty()) spawns = arena.spawnGroup("team-" + team);
+        if (spawns.isEmpty()) spawns = arena.spawnGroup("default");
+        if (spawns.isEmpty()) return arena.anchor();
         return pickLeastCrowded(spawns, Bukkit.getOnlinePlayers(), 10.0);
     }
 
     @Override
     public boolean allowHubEntrance(ModeLobbyContext ctx) {
-        return true;
+        return state.config().entranceEnabled();
     }
 
     @Override
     public int selectableTeamCount(ModeLobbyContext ctx) {
-        return BattleModeConfig.from(ctx.runtime().cfg()).maxTeam();
+        return state.config().maxTeam();
     }
 
     @Override
     public void onEnterGame(ModePlayerContext ctx) {
         Player player = ctx.player();
+        var playerSession = ctx.session();
+
+        state.markFighter(playerSession);
+
         player.setGameMode(GameMode.ADVENTURE);
-        kit.apply(player, ctx.session());
-        Msg.actionBar(player, Component.text("进入游戏"));
+        kit.apply(player, playerSession);
+        Msg.actionBar(player, Component.text("进入 battle 战场"));
     }
 
     private Location pickLeastCrowded(

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattlePlayerFlow.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattlePlayerFlow.java
@@ -52,6 +52,11 @@ public final class BattlePlayerFlow implements IModePlayerFlow {
     }
 
     @Override
+    public boolean allowHubEntrance(ModeLobbyContext ctx) {
+        return true;
+    }
+
+    @Override
     public int selectableTeamCount(ModeLobbyContext ctx) {
         return BattleModeConfig.from(ctx.runtime().cfg()).maxTeam();
     }

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleRules.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleRules.java
@@ -1,29 +1,24 @@
 package top.ourisland.creepersiarena.game.mode.impl.battle;
 
-import top.ourisland.creepersiarena.api.game.GameSession;
 import top.ourisland.creepersiarena.api.game.flow.decision.JoinDecision;
 import top.ourisland.creepersiarena.api.game.flow.decision.RespawnDecision;
 import top.ourisland.creepersiarena.api.game.mode.GameModeType;
-import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
 import top.ourisland.creepersiarena.api.game.mode.IModeRules;
 import top.ourisland.creepersiarena.api.game.mode.context.JoinContext;
 import top.ourisland.creepersiarena.api.game.mode.context.LeaveContext;
 import top.ourisland.creepersiarena.api.game.mode.context.RespawnContext;
-import top.ourisland.creepersiarena.game.mode.impl.battle.config.BattleModeConfig;
 
 public final class BattleRules implements IModeRules {
 
-    private final GameRuntime runtime;
-    private final GameSession session;
+    private final BattleState state;
 
-    public BattleRules(GameRuntime runtime, GameSession session) {
-        this.runtime = runtime;
-        this.session = session;
+    public BattleRules(BattleState state) {
+        this.state = state;
     }
 
     @Override
     public GameModeType type() {
-        return GameModeType.of("battle");
+        return BattleState.TYPE;
     }
 
     @Override
@@ -33,12 +28,17 @@ public final class BattleRules implements IModeRules {
 
     @Override
     public void onLeave(LeaveContext ctx) {
+        if (ctx != null && ctx.session() != null) {
+            state.clearFighter(ctx.session());
+        }
     }
 
     @Override
     public RespawnDecision onRespawn(RespawnContext ctx) {
-        var config = BattleModeConfig.from(runtime.cfg());
-        return new RespawnDecision.RespawnLobbyCountdown(config.respawnTimeSeconds());
+        if (ctx == null || ctx.session() == null || !state.session().players().contains(ctx.player().getUniqueId())) {
+            return new RespawnDecision.Hub();
+        }
+        return new RespawnDecision.RespawnLobbyCountdown(state.config().respawnTimeSeconds());
     }
 
 }

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleState.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleState.java
@@ -1,6 +1,7 @@
 package top.ourisland.creepersiarena.game.mode.impl.battle;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import top.ourisland.creepersiarena.api.game.GameSession;
@@ -18,8 +19,8 @@ import java.util.UUID;
 public final class BattleState {
 
     static final GameModeType TYPE = GameModeType.of("battle");
-    private static final String MODE_DATA_PREFIX = "battle:";
-    private static final String PARTICIPANT_KEY = MODE_DATA_PREFIX + "participant";
+    static final String MODE_DATA_PREFIX = "battle:";
+    static final String PARTICIPANT_KEY = MODE_DATA_PREFIX + "participant";
 
     private final GameRuntime runtime;
     private final GameSession session;
@@ -33,6 +34,10 @@ public final class BattleState {
         this.runtime = runtime;
         this.session = session;
         this.config = config;
+    }
+
+    static boolean markedFighter(PlayerSession player) {
+        return player != null && player.modeBoolean(PARTICIPANT_KEY, false);
     }
 
     public GameSession session() {
@@ -122,8 +127,26 @@ public final class BattleState {
     }
 
     public Component mapFinishedMessage() {
-        return Component.text("§6Battle map complete: §e" + session.arena().id()
-                + " §8| §f" + scoreSummary());
+        return Component.text("Battle map complete: ", NamedTextColor.GOLD)
+                .append(Component.text(session.arena().id(), NamedTextColor.YELLOW))
+                .append(Component.text(" | ", NamedTextColor.DARK_GRAY))
+                .append(scoreSummaryComponent());
+    }
+
+    public Component scoreSummaryComponent() {
+        if (teamKills.isEmpty()) return Component.text("no kills recorded", NamedTextColor.GRAY);
+
+        Component out = Component.empty();
+        boolean first = true;
+        for (int team = 1; team <= config.maxTeam(); team++) {
+            int kills = teamKills.getOrDefault(team, 0);
+            if (kills <= 0) continue;
+            if (!first) out = out.append(Component.text(" / ", NamedTextColor.GRAY));
+            out = out.append(Component.text("Team " + team + " ", NamedTextColor.GRAY))
+                    .append(Component.text(kills, NamedTextColor.WHITE));
+            first = false;
+        }
+        return first ? Component.text("no kills recorded", NamedTextColor.GRAY) : out;
     }
 
     public String scoreSummary() {
@@ -134,8 +157,8 @@ public final class BattleState {
         for (int team = 1; team <= config.maxTeam(); team++) {
             int kills = teamKills.getOrDefault(team, 0);
             if (kills <= 0) continue;
-            if (!first) out.append(" §7/ ");
-            out.append("Team ").append(team).append(" §f").append(kills);
+            if (!first) out.append(" / ");
+            out.append("Team ").append(team).append(" ").append(kills);
             first = false;
         }
         return first ? "no kills recorded" : out.toString();

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleState.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleState.java
@@ -1,0 +1,144 @@
+package top.ourisland.creepersiarena.game.mode.impl.battle;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import top.ourisland.creepersiarena.api.game.GameSession;
+import top.ourisland.creepersiarena.api.game.mode.GameModeType;
+import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
+import top.ourisland.creepersiarena.api.game.player.PlayerState;
+import top.ourisland.creepersiarena.game.mode.impl.battle.config.BattleModeConfig;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public final class BattleState {
+
+    static final GameModeType TYPE = GameModeType.of("battle");
+    private static final String MODE_DATA_PREFIX = "battle:";
+    private static final String PARTICIPANT_KEY = MODE_DATA_PREFIX + "participant";
+
+    private final GameRuntime runtime;
+    private final GameSession session;
+    private final BattleModeConfig config;
+    private final Map<Integer, Integer> teamKills = new LinkedHashMap<>();
+
+    private int mapProgress;
+    private boolean rotationPending;
+
+    public BattleState(GameRuntime runtime, GameSession session, BattleModeConfig config) {
+        this.runtime = runtime;
+        this.session = session;
+        this.config = config;
+    }
+
+    public GameSession session() {
+        return session;
+    }
+
+    public BattleModeConfig config() {
+        return config;
+    }
+
+    public int mapProgress() {
+        return mapProgress;
+    }
+
+    public float progressRatio() {
+        return Math.clamp((float) mapProgress / config.mapProgressTarget(), 0.0F, 1.0F);
+    }
+
+    public boolean rotationPending() {
+        return rotationPending;
+    }
+
+    public void rotationPending(boolean rotationPending) {
+        this.rotationPending = rotationPending;
+    }
+
+    public void markFighter(PlayerSession player) {
+        if (player == null) return;
+        player.modeData(PARTICIPANT_KEY, true);
+    }
+
+    public void clearFighter(PlayerSession player) {
+        if (player == null) return;
+        player.clearModeData(MODE_DATA_PREFIX);
+    }
+
+    public Set<UUID> players() {
+        return session.players();
+    }
+
+    public boolean recordKill(Player killer, Player victim) {
+        if (killer == null || victim == null || killer.equals(victim)) return false;
+        if (!isFighter(killer) || !isFighter(victim)) return false;
+
+        PlayerSession killerSession = runtime.sessionStore().get(killer);
+        PlayerSession victimSession = runtime.sessionStore().get(victim);
+        if (sameTeam(killerSession, victimSession)) return false;
+
+        int team = teamOf(killerSession);
+        teamKills.merge(team, 1, Integer::sum);
+
+        int delta = config.killProgressForPopulation(onlineFighterCount());
+        mapProgress = Math.min(config.mapProgressTarget(), mapProgress + delta);
+        return true;
+    }
+
+    public boolean isFighter(Player player) {
+        if (player == null || !player.isOnline()) return false;
+        if (!session.players().contains(player.getUniqueId())) return false;
+        PlayerSession playerSession = runtime.sessionStore().get(player);
+        return playerSession != null && playerSession.state() == PlayerState.IN_GAME;
+    }
+
+    private boolean sameTeam(PlayerSession left, PlayerSession right) {
+        if (left == null || right == null) return false;
+        Integer leftTeam = left.selectedTeam();
+        Integer rightTeam = right.selectedTeam();
+        return leftTeam != null && leftTeam.equals(rightTeam);
+    }
+
+    private int teamOf(PlayerSession session) {
+        if (session == null || session.selectedTeam() == null) return 0;
+        return Math.clamp(session.selectedTeam(), 1, config.maxTeam());
+    }
+
+    public int onlineFighterCount() {
+        int count = 0;
+        for (UUID uuid : session.players()) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (isFighter(player)) count++;
+        }
+        return count;
+    }
+
+    public boolean reachedMapTarget() {
+        return mapProgress >= config.mapProgressTarget();
+    }
+
+    public Component mapFinishedMessage() {
+        return Component.text("§6Battle map complete: §e" + session.arena().id()
+                + " §8| §f" + scoreSummary());
+    }
+
+    public String scoreSummary() {
+        if (teamKills.isEmpty()) return "no kills recorded";
+
+        StringBuilder out = new StringBuilder();
+        boolean first = true;
+        for (int team = 1; team <= config.maxTeam(); team++) {
+            int kills = teamKills.getOrDefault(team, 0);
+            if (kills <= 0) continue;
+            if (!first) out.append(" §7/ ");
+            out.append("Team ").append(team).append(" §f").append(kills);
+            first = false;
+        }
+        return first ? "no kills recorded" : out.toString();
+    }
+
+}

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleTeamBalancer.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleTeamBalancer.java
@@ -1,0 +1,86 @@
+package top.ourisland.creepersiarena.game.mode.impl.battle;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
+import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
+import top.ourisland.creepersiarena.game.mode.impl.battle.config.BattleModeConfig;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class BattleTeamBalancer {
+
+    private final BattleModeConfig config;
+    private final PlayerSessionStore sessions;
+
+    public BattleTeamBalancer(BattleModeConfig config, PlayerSessionStore sessions) {
+        this.config = config;
+        this.sessions = sessions;
+    }
+
+    public int assign(PlayerSession target, Collection<UUID> activePlayers) {
+        if (target == null) return 1;
+
+        Integer requested = normalized(target.selectedTeam());
+        if (target.modeBoolean("battle:participant", false) && requested != null) {
+            return requested;
+        }
+
+        int team;
+        if (requested != null && !config.forceBalancing()) {
+            team = requested;
+        } else if (config.teamAutoBalancing()) {
+            team = leastPopulatedTeam(activePlayers, target.playerId());
+        } else {
+            team = requested == null ? randomTeam() : requested;
+        }
+
+        target.selectedTeam(team);
+        target.selectedTeamKey(String.valueOf(team));
+        return team;
+    }
+
+    private Integer normalized(Integer requested) {
+        if (requested == null) return null;
+        if (requested < 1 || requested > config.maxTeam()) return null;
+        return requested;
+    }
+
+    private int leastPopulatedTeam(Collection<UUID> activePlayers, UUID joiningPlayer) {
+        Map<Integer, Integer> counts = new LinkedHashMap<>();
+        for (int team = 1; team <= config.maxTeam(); team++) {
+            counts.put(team, 0);
+        }
+
+        if (activePlayers != null) {
+            for (UUID id : activePlayers) {
+                if (id == null || id.equals(joiningPlayer)) continue;
+                Player online = Bukkit.getPlayer(id);
+                if (online == null || !online.isOnline()) continue;
+                PlayerSession player = sessions.get(online);
+                if (player == null) continue;
+                Integer team = normalized(player.selectedTeam());
+                if (team != null) counts.merge(team, 1, Integer::sum);
+            }
+        }
+
+        int bestTeam = 1;
+        int bestCount = Integer.MAX_VALUE;
+        for (var entry : counts.entrySet()) {
+            if (entry.getValue() < bestCount) {
+                bestTeam = entry.getKey();
+                bestCount = entry.getValue();
+            }
+        }
+        return bestTeam;
+    }
+
+    private int randomTeam() {
+        return ThreadLocalRandom.current().nextInt(1, config.maxTeam() + 1);
+    }
+
+}

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleTeamBalancer.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleTeamBalancer.java
@@ -26,7 +26,7 @@ public final class BattleTeamBalancer {
         if (target == null) return 1;
 
         Integer requested = normalized(target.selectedTeam());
-        if (target.modeBoolean("battle:participant", false) && requested != null) {
+        if (BattleState.markedFighter(target) && requested != null) {
             return requested;
         }
 

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleTimeline.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleTimeline.java
@@ -1,47 +1,54 @@
 package top.ourisland.creepersiarena.game.mode.impl.battle;
 
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-import top.ourisland.creepersiarena.api.game.GameSession;
 import top.ourisland.creepersiarena.api.game.flow.action.GameAction;
 import top.ourisland.creepersiarena.api.game.mode.GameModeType;
-import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
 import top.ourisland.creepersiarena.api.game.mode.IModeTimeline;
 import top.ourisland.creepersiarena.api.game.mode.context.TickContext;
-import top.ourisland.creepersiarena.game.mode.impl.battle.config.BattleModeConfig;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 public final class BattleTimeline implements IModeTimeline {
 
-    private final GameRuntime runtime;
-    private final GameSession session;
+    private final BattleState state;
+    private final BattleBossBars bossBars;
 
-    private int remaining;
-
-    public BattleTimeline(GameRuntime runtime, GameSession session) {
-        this.runtime = runtime;
-        this.session = session;
-        this.remaining = BattleModeConfig.from(runtime.cfg()).singleGameTimeSeconds();
+    public BattleTimeline(BattleState state, BattleBossBars bossBars) {
+        this.state = state;
+        this.bossBars = bossBars;
     }
 
     @Override
     public GameModeType type() {
-        return GameModeType.of("battle");
+        return BattleState.TYPE;
     }
 
     @Override
     public List<GameAction> tick(TickContext ctx) {
-        if (remaining <= 0) return List.of();
+        if (state.rotationPending()) return List.of();
 
-        remaining--;
-        if (remaining > 0) return List.of();
+        bossBars.update(state);
+        if (!state.reachedMapTarget()) return List.of();
 
-        // TODO: 结算/换图：先最小实现 -> 全部回 hub
-        return List.of(
-                new GameAction.Broadcast(Component.text("BATTLE：本局结束！", NamedTextColor.GOLD)),
-                new GameAction.EndGameAndBackToHub("BATTLE_TIMEOUT")
-        );
+        state.rotationPending(true);
+        bossBars.hide();
+
+        Set<UUID> players = Set.copyOf(state.players());
+        var actions = new ArrayList<GameAction>();
+        actions.add(new GameAction.Broadcast(state.mapFinishedMessage()));
+        actions.add(new GameAction.ToHub(players));
+        actions.add(new GameAction.RotateArena("battle map progress reached"));
+        return actions;
+    }
+
+    public BattleState state() {
+        return state;
+    }
+
+    public void hideBossBars() {
+        bossBars.hide();
     }
 
 }

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleTimeline.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/BattleTimeline.java
@@ -43,12 +43,17 @@ public final class BattleTimeline implements IModeTimeline {
         return actions;
     }
 
-    public BattleState state() {
-        return state;
+    @Override
+    public void onStop(TickContext ctx) {
+        hideBossBars();
     }
 
     public void hideBossBars() {
         bossBars.hide();
+    }
+
+    public BattleState state() {
+        return state;
     }
 
 }

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/config/BattleModeConfig.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/battle/config/BattleModeConfig.java
@@ -1,6 +1,10 @@
 package top.ourisland.creepersiarena.game.mode.impl.battle.config;
 
+import org.bukkit.configuration.ConfigurationSection;
 import top.ourisland.creepersiarena.api.config.IGameConfigView;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Battle-owned global mode configuration. This type intentionally lives with default content, not core.
@@ -10,17 +14,106 @@ public record BattleModeConfig(
         int respawnTimeSeconds,
         int maxTeam,
         boolean teamAutoBalancing,
-        boolean forceBalancing
+        boolean forceBalancing,
+        int mapProgressTarget,
+        boolean entranceEnabled,
+        Map<String, Integer> killProgress
 ) {
 
+    private static final Map<String, Integer> DEFAULT_KILL_PROGRESS = Map.of(
+            "1-2", 100,
+            "3-4", 75,
+            "5-7", 60,
+            "8-10", 45,
+            "11-14", 30,
+            "15+", 20
+    );
+
+    public BattleModeConfig {
+        singleGameTimeSeconds = Math.max(0, singleGameTimeSeconds);
+        respawnTimeSeconds = Math.max(0, respawnTimeSeconds);
+        maxTeam = Math.max(1, maxTeam);
+        mapProgressTarget = Math.max(1, mapProgressTarget);
+        killProgress = Map.copyOf(killProgress == null || killProgress.isEmpty()
+                ? DEFAULT_KILL_PROGRESS
+                : killProgress);
+    }
+
     public static BattleModeConfig from(IGameConfigView config) {
+        ConfigurationSection section = config == null ? null : config.modeSection("battle");
         return new BattleModeConfig(
-                config.modeInt("battle", "single-game-time", 600),
-                config.modeInt("battle", "respawn-time", 10),
-                Math.max(1, config.modeInt("battle", "max-team", 4)),
-                config.modeBoolean("battle", "team-auto-balancing", true),
-                config.modeBoolean("battle", "force-balancing", false)
+                intValue(section, config, "single-game-time", 600),
+                intValue(section, config, "respawn-time", 8),
+                intValue(section, config, "max-team", 4),
+                boolValue(section, config, "team-auto-balancing", true),
+                boolValue(section, config, "force-balancing", false),
+                intValue(section, config, "map-progress-target", 4000),
+                boolValue(section, config, "entrance-enabled", true),
+                killProgress(section)
         );
+    }
+
+    private static int intValue(
+            ConfigurationSection section,
+            IGameConfigView config,
+            String key,
+            int fallback
+    ) {
+        if (section != null) return section.getInt(key, fallback);
+        return config == null ? fallback : config.modeInt("battle", key, fallback);
+    }
+
+    private static boolean boolValue(
+            ConfigurationSection section,
+            IGameConfigView config,
+            String key,
+            boolean fallback
+    ) {
+        if (section != null) return section.getBoolean(key, fallback);
+        return config == null ? fallback : config.modeBoolean("battle", key, fallback);
+    }
+
+    private static Map<String, Integer> killProgress(ConfigurationSection section) {
+        var progress = section == null ? null : section.getConfigurationSection("kill-progress");
+        if (progress == null) return DEFAULT_KILL_PROGRESS;
+
+        var values = new LinkedHashMap<String, Integer>();
+        for (String key : progress.getKeys(false)) {
+            int value = progress.getInt(key, 0);
+            if (value > 0) values.put(key, value);
+        }
+        return values.isEmpty() ? DEFAULT_KILL_PROGRESS : values;
+    }
+
+    public int killProgressForPopulation(int population) {
+        int players = Math.max(1, population);
+        for (var entry : killProgress.entrySet()) {
+            if (matchesPopulation(entry.getKey(), players)) return Math.max(1, entry.getValue());
+        }
+        return players >= 15 ? 20 : 100;
+    }
+
+    private boolean matchesPopulation(String expression, int players) {
+        if (expression == null || expression.isBlank()) return false;
+        String trimmed = expression.trim();
+        if (trimmed.endsWith("+")) {
+            return players >= parseInt(trimmed.substring(0, trimmed.length() - 1), Integer.MAX_VALUE);
+        }
+        int dash = trimmed.indexOf('-');
+        if (dash >= 0) {
+            int min = parseInt(trimmed.substring(0, dash), Integer.MAX_VALUE);
+            int max = parseInt(trimmed.substring(dash + 1), Integer.MIN_VALUE);
+            return players >= min && players <= max;
+        }
+        return players == parseInt(trimmed, Integer.MIN_VALUE);
+    }
+
+    private int parseInt(String value, int fallback) {
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (RuntimeException _) {
+            return fallback;
+        }
     }
 
 }

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/config/StealModeConfig.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/config/StealModeConfig.java
@@ -68,12 +68,11 @@ public record StealModeConfig(
     }
 
     public int requiredReadyPlayers(int population) {
-        if (population <= 0) return minPlayerToStart();
-        int required = minPlayerToStart();
+        int required = Math.max(2, minPlayerToStart());
         if (dynamicReadyRequirement()) {
             required = Math.max(required, datapackLikeRequirement(population));
         }
-        return Math.min(population, required);
+        return required;
     }
 
     private int datapackLikeRequirement(int population) {

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/config/StealModeConfig.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/config/StealModeConfig.java
@@ -18,7 +18,9 @@ public record StealModeConfig(
         int scoreToWin,
         int roundCelebrationSeconds,
         int gameEndCelebrationSeconds,
-        int mineCooldownSeconds
+        int mineCooldownSeconds,
+        boolean allowLobbyJobSelection,
+        boolean allowRespawnJobSelection
 ) {
 
     public static StealModeConfig from(IGameConfigView config) {
@@ -44,7 +46,9 @@ public record StealModeConfig(
                         intValue(section, config, "round-end-seconds", 5))),
                 Math.max(1, intValue(section, config, "game-end-celebration-time",
                         intValue(section, config, "game-end-seconds", 10))),
-                Math.max(0, intValue(section, config, "mine-cooldown-seconds", 3))
+                Math.max(0, intValue(section, config, "mine-cooldown-seconds", 3)),
+                boolValue(section, config, "allow-lobby-job-selection", false),
+                boolValue(section, config, "allow-respawn-job-selection", false)
         );
     }
 

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealBossBars.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealBossBars.java
@@ -25,7 +25,7 @@ final class StealBossBars {
         waiting.name(waitingName(ready, needed, countdownRemaining));
         waiting.progress(ratio(countdownRemaining > 0 ? countdownRemaining : ready, countdownRemaining > 0
                 ? countdownMax
-                : Math.max(1, population)));
+                : Math.max(1, needed)));
         waiting.color(countdownRemaining > 0 ? BossBar.Color.GREEN : BossBar.Color.RED);
         sync(waiting, players);
         hideAllExcept(waiting, players);

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealBossBars.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealBossBars.java
@@ -65,8 +65,9 @@ final class StealBossBars {
 
         for (Player p : players) {
             if (p == null || !p.isOnline()) continue;
-            p.showBossBar(bar);
-            current.add(p.getUniqueId());
+            if (current.add(p.getUniqueId())) {
+                p.showBossBar(bar);
+            }
         }
     }
 

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
@@ -20,8 +20,6 @@ import top.ourisland.creepersiarena.api.game.player.PlayerSession;
 import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
 import top.ourisland.creepersiarena.game.GameManager;
-import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealArenaConfig;
-import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealModeConfig;
 import top.ourisland.creepersiarena.game.mode.impl.steal.model.StealTeam;
 
 public final class StealGameplayListener implements Listener {
@@ -108,15 +106,13 @@ public final class StealGameplayListener implements Listener {
             return;
         }
 
-        var arenaConfig = StealArenaConfig.from(active.session().arena());
-        boolean target = arenaConfig.isRedstoneTarget(event.getBlock()) && isRedstoneOre(event.getBlock().getType());
+        boolean target = active.state().arenaConfig().isRedstoneTarget(event.getBlock()) && isRedstoneOre(event.getBlock().getType());
         if (!target) {
             event.setCancelled(true);
             return;
         }
 
-        boolean accepted = active.timeline()
-                .onMinedRedstone(player, StealModeConfig.from(active.timeline().runtime().cfg()));
+        boolean accepted = active.timeline().onMinedRedstone(player, active.state().modeConfig());
         if (!accepted) {
             event.setCancelled(true);
             return;

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
@@ -1,18 +1,27 @@
 package top.ourisland.creepersiarena.game.mode.impl.steal.runtime;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.projectiles.ProjectileSource;
 import top.ourisland.creepersiarena.api.game.GameSession;
 import top.ourisland.creepersiarena.api.game.mode.GameModeType;
@@ -21,15 +30,133 @@ import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
 import top.ourisland.creepersiarena.game.GameManager;
 import top.ourisland.creepersiarena.game.mode.impl.steal.model.StealTeam;
+import top.ourisland.creepersiarena.utils.Msg;
 
 public final class StealGameplayListener implements Listener {
 
     private final GameManager gameManager;
     private final PlayerSessionStore sessions;
+    private final StealReadyItemCodec readyItems = new StealReadyItemCodec();
 
     public StealGameplayListener(GameManager gameManager, PlayerSessionStore sessions) {
         this.gameManager = gameManager;
         this.sessions = sessions;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onReadyInteract(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        if (event.getAction() == Action.PHYSICAL) return;
+
+        if (readyItems.isReadyButton(event.getItem())) {
+            var active = activeSteal();
+            if (active == null) return;
+
+            event.setCancelled(true);
+            toggleReady(event.getPlayer(), active);
+            return;
+        }
+
+        if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
+            var active = activeSteal();
+            if (active == null || active.state().phase != StealPhase.ROUND_PLAYING) return;
+            Block block = event.getClickedBlock();
+            if (block == null || !isRedstoneOre(block.getType()) || !active.state()
+                    .arenaConfig()
+                    .isRedstoneTarget(block)) {
+                return;
+            }
+
+            event.setCancelled(true);
+            tryMineRedstone(event.getPlayer(), block, active);
+        }
+    }
+
+    private ActiveSteal activeSteal() {
+        GameSession session = gameManager.active();
+        if (session == null || !session.mode().equals(GameModeType.of("steal"))) return null;
+        if (!(gameManager.timeline() instanceof StealTimeline timeline)) return null;
+        return new ActiveSteal(session, timeline, timeline.state());
+    }
+
+    private void toggleReady(Player player, ActiveSteal active) {
+        if (player == null || active == null) return;
+        if (!isWaitingHub(player, active)) {
+            Msg.actionBar(player, Component.text("当前阶段不能切换准备", NamedTextColor.RED));
+            return;
+        }
+
+        PlayerSession session = sessions.getOrCreate(player);
+        boolean next = !StealPlayerState.ready(session);
+        StealPlayerState.ready(session, next);
+        StealPlayerState.participant(session, false);
+        StealPlayerState.alive(session, false);
+        active.session().addPlayer(player.getUniqueId());
+
+        int ready = active.timeline().countReadyOnline();
+        int required = active.state().modeConfig().requiredReadyPlayers(org.bukkit.Bukkit.getOnlinePlayers().size());
+        player.getInventory().setItem(0, readyItems.readyButton(next, ready, required));
+
+        player.playSound(player, next
+                ? Sound.BLOCK_NOTE_BLOCK_PLING
+                : Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, SoundCategory.PLAYERS, 1.0f, next ? 2.0f : 1.0f);
+        Msg.actionBar(player, next
+                ? Component.text("✪ 你已准备加入偷窃模式", NamedTextColor.GREEN)
+                : Component.text("✪ 你取消了准备", NamedTextColor.GRAY));
+    }
+
+    private boolean isRedstoneOre(Material material) {
+        return material == Material.DEEPSLATE_REDSTONE_ORE || material == Material.REDSTONE_ORE;
+    }
+
+    private boolean tryMineRedstone(Player player, Block block, ActiveSteal active) {
+        if (player == null || block == null || active == null) return false;
+        boolean accepted = active.timeline().onMinedRedstone(player, active.state().modeConfig());
+        if (!accepted) return false;
+
+        block.setType(Material.AIR, false);
+        player.playSound(player, Sound.BLOCK_DEEPSLATE_BREAK, SoundCategory.BLOCKS, 1.0f, 1.0f);
+        return true;
+    }
+
+    private boolean isWaitingHub(Player player, ActiveSteal active) {
+        if (player == null || active == null) return false;
+        if (active.state().phase != StealPhase.LOBBY && active.state().phase != StealPhase.START_COUNTDOWN)
+            return false;
+        PlayerSession session = sessions.get(player);
+        return session != null && session.state() == PlayerState.HUB;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onReadyClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        if (!readyItems.isReadyButton(event.getCurrentItem())) return;
+
+        var active = activeSteal();
+        if (active == null) return;
+
+        event.setCancelled(true);
+        toggleReady(player, active);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onReadyDrag(InventoryDragEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        var active = activeSteal();
+        if (active == null || !isWaitingHub(player, active)) return;
+        if (event.getRawSlots().contains(0)) event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onReadySwap(PlayerSwapHandItemsEvent event) {
+        if (!readyItems.isReadyButton(event.getMainHandItem()) && !readyItems.isReadyButton(event.getOffHandItem()))
+            return;
+
+        var active = activeSteal();
+        if (active == null) return;
+
+        event.setCancelled(true);
+        toggleReady(event.getPlayer(), active);
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
@@ -45,13 +172,6 @@ public final class StealGameplayListener implements Listener {
         if (active.state().phase != StealPhase.ROUND_PLAYING) {
             event.setCancelled(true);
         }
-    }
-
-    private ActiveSteal activeSteal() {
-        GameSession session = gameManager.active();
-        if (session == null || !session.mode().equals(GameModeType.of("steal"))) return null;
-        if (!(gameManager.timeline() instanceof StealTimeline timeline)) return null;
-        return new ActiveSteal(session, timeline, timeline.state());
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
@@ -106,14 +226,10 @@ public final class StealGameplayListener implements Listener {
             return;
         }
 
-        boolean target = active.state().arenaConfig().isRedstoneTarget(event.getBlock()) && isRedstoneOre(event.getBlock().getType());
+        boolean target = active.state()
+                .arenaConfig()
+                .isRedstoneTarget(event.getBlock()) && isRedstoneOre(event.getBlock().getType());
         if (!target) {
-            event.setCancelled(true);
-            return;
-        }
-
-        boolean accepted = active.timeline().onMinedRedstone(player, active.state().modeConfig());
-        if (!accepted) {
             event.setCancelled(true);
             return;
         }
@@ -121,12 +237,7 @@ public final class StealGameplayListener implements Listener {
         event.setCancelled(true);
         event.setDropItems(false);
         event.setExpToDrop(0);
-        event.getBlock().setType(Material.AIR, false);
-        player.playSound(player, Sound.BLOCK_DEEPSLATE_BREAK, SoundCategory.BLOCKS, 1.0f, 1.0f);
-    }
-
-    private boolean isRedstoneOre(Material material) {
-        return material == Material.DEEPSLATE_REDSTONE_ORE || material == Material.REDSTONE_ORE;
+        tryMineRedstone(player, event.getBlock(), active);
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
@@ -1,7 +1,5 @@
 package top.ourisland.creepersiarena.game.mode.impl.steal.runtime;
 
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
@@ -30,13 +28,11 @@ import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
 import top.ourisland.creepersiarena.game.GameManager;
 import top.ourisland.creepersiarena.game.mode.impl.steal.model.StealTeam;
-import top.ourisland.creepersiarena.utils.Msg;
 
 public final class StealGameplayListener implements Listener {
 
     private final GameManager gameManager;
     private final PlayerSessionStore sessions;
-    private final StealReadyItemCodec readyItems = new StealReadyItemCodec();
 
     public StealGameplayListener(GameManager gameManager, PlayerSessionStore sessions) {
         this.gameManager = gameManager;
@@ -48,12 +44,10 @@ public final class StealGameplayListener implements Listener {
         if (event.getHand() != EquipmentSlot.HAND) return;
         if (event.getAction() == Action.PHYSICAL) return;
 
-        if (readyItems.isReadyButton(event.getItem())) {
-            var active = activeSteal();
-            if (active == null) return;
-
+        var readyActive = activeSteal();
+        if (readyActive != null && readyActive.timeline().isReadyButton(event.getItem())) {
             event.setCancelled(true);
-            toggleReady(event.getPlayer(), active);
+            readyActive.timeline().toggleReady(event.getPlayer());
             return;
         }
 
@@ -79,32 +73,6 @@ public final class StealGameplayListener implements Listener {
         return new ActiveSteal(session, timeline, timeline.state());
     }
 
-    private void toggleReady(Player player, ActiveSteal active) {
-        if (player == null || active == null) return;
-        if (!isWaitingHub(player, active)) {
-            Msg.actionBar(player, Component.text("当前阶段不能切换准备", NamedTextColor.RED));
-            return;
-        }
-
-        PlayerSession session = sessions.getOrCreate(player);
-        boolean next = !StealPlayerState.ready(session);
-        StealPlayerState.ready(session, next);
-        StealPlayerState.participant(session, false);
-        StealPlayerState.alive(session, false);
-        active.session().addPlayer(player.getUniqueId());
-
-        int ready = active.timeline().countReadyOnline();
-        int required = active.state().modeConfig().requiredReadyPlayers(org.bukkit.Bukkit.getOnlinePlayers().size());
-        player.getInventory().setItem(0, readyItems.readyButton(next, ready, required));
-
-        player.playSound(player, next
-                ? Sound.BLOCK_NOTE_BLOCK_PLING
-                : Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, SoundCategory.PLAYERS, 1.0f, next ? 2.0f : 1.0f);
-        Msg.actionBar(player, next
-                ? Component.text("✪ 你已准备加入偷窃模式", NamedTextColor.GREEN)
-                : Component.text("✪ 你取消了准备", NamedTextColor.GRAY));
-    }
-
     private boolean isRedstoneOre(Material material) {
         return material == Material.DEEPSLATE_REDSTONE_ORE || material == Material.REDSTONE_ORE;
     }
@@ -119,44 +87,37 @@ public final class StealGameplayListener implements Listener {
         return true;
     }
 
-    private boolean isWaitingHub(Player player, ActiveSteal active) {
-        if (player == null || active == null) return false;
-        if (active.state().phase != StealPhase.LOBBY && active.state().phase != StealPhase.START_COUNTDOWN)
-            return false;
-        PlayerSession session = sessions.get(player);
-        return session != null && session.state() == PlayerState.HUB;
-    }
-
     @EventHandler(priority = EventPriority.LOWEST)
     public void onReadyClick(InventoryClickEvent event) {
         if (!(event.getWhoClicked() instanceof Player player)) return;
-        if (!readyItems.isReadyButton(event.getCurrentItem())) return;
-
         var active = activeSteal();
-        if (active == null) return;
+        if (active == null || !active.timeline().isReadyButton(event.getCurrentItem())) return;
 
         event.setCancelled(true);
-        toggleReady(player, active);
+        active.timeline().toggleReady(player);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onReadyDrag(InventoryDragEvent event) {
         if (!(event.getWhoClicked() instanceof Player player)) return;
         var active = activeSteal();
-        if (active == null || !isWaitingHub(player, active)) return;
+        if (active == null) return;
+        PlayerSession session = sessions.get(player);
+        if (session == null || session.state() != PlayerState.HUB) return;
         if (event.getRawSlots().contains(0)) event.setCancelled(true);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onReadySwap(PlayerSwapHandItemsEvent event) {
-        if (!readyItems.isReadyButton(event.getMainHandItem()) && !readyItems.isReadyButton(event.getOffHandItem()))
-            return;
-
         var active = activeSteal();
         if (active == null) return;
+        if (!active.timeline().isReadyButton(event.getMainHandItem())
+                && !active.timeline().isReadyButton(event.getOffHandItem())) {
+            return;
+        }
 
         event.setCancelled(true);
-        toggleReady(event.getPlayer(), active);
+        active.timeline().toggleReady(event.getPlayer());
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLobbyUi.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLobbyUi.java
@@ -1,80 +1,74 @@
 package top.ourisland.creepersiarena.game.mode.impl.steal.runtime;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
+import top.ourisland.creepersiarena.api.game.GameSession;
 import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
 import top.ourisland.creepersiarena.api.game.player.PlayerSession;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
-import top.ourisland.creepersiarena.config.ConfigManager;
-import top.ourisland.creepersiarena.game.lobby.item.LobbyItemService;
 
 /**
  * Steal-owned lobby presentation.
  * <p>
- * Core still provides the low-level inventory clearing and the generic two-team cycle button, while the ready control
- * is owned and marked by steal so it cannot be confused with enter-game actions.
+ * The ready button itself is rendered and updated by {@link StealReadyController}; this class only decides when that
+ * waiting UI belongs in a player's inventory.
  */
 final class StealLobbyUi {
 
-    private final GameRuntime runtime;
     private final StealState state;
-    private final LobbyItemService lobbyItems;
-    private final ConfigManager configManager;
-    private final StealReadyItemCodec readyItems = new StealReadyItemCodec();
+    private final StealReadyController readyController;
 
-    StealLobbyUi(GameRuntime runtime, StealState state) {
-        this.runtime = runtime;
+    StealLobbyUi(StealState state, StealReadyController readyController) {
         this.state = state;
-        this.lobbyItems = runtime.requireService(LobbyItemService.class);
-        this.configManager = runtime.requireService(ConfigManager.class);
+        this.readyController = readyController;
     }
 
     void refreshWaiting(Player player, PlayerSession session) {
-        refreshWaiting(player, session, countReadyOnline(), requiredReadyPlayers());
+        readyController.refreshWaiting(player, session);
     }
 
-    void refreshWaiting(Player player, PlayerSession session, int ready, int required) {
-        if (player == null || session == null || session.state() != PlayerState.HUB) return;
-        if (state.phase != StealPhase.LOBBY && state.phase != StealPhase.START_COUNTDOWN) return;
-
-        lobbyItems.applyHubKit(player, session, configManager.globalConfig(), 2, false);
-        decorateWaitingInventory(session, player.getInventory(), ready, required);
+    void refreshWaiting(
+            Player player,
+            PlayerSession session,
+            int ready,
+            int required
+    ) {
+        readyController.refreshWaiting(player, session, ready, required);
     }
 
     int countReadyOnline() {
-        int count = 0;
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            PlayerSession session = runtime.sessionStore().get(player);
-            if (StealPlayerState.ready(session)) count++;
-        }
-        return count;
+        return readyController.countReadyOnline();
     }
 
     int requiredReadyPlayers() {
-        return state.modeConfig().requiredReadyPlayers(Bukkit.getOnlinePlayers().size());
+        return readyController.requiredReadyPlayers();
     }
 
-    private void decorateWaitingInventory(PlayerSession session, PlayerInventory inventory, int ready, int required) {
-        inventory.setItem(0, readyItems.readyButton(StealPlayerState.ready(session), ready, required));
+    boolean isReadyButton(ItemStack item) {
+        return readyController.isReadyButton(item);
+    }
+
+    boolean toggleReady(Player player, GameSession session) {
+        return readyController.toggleReady(player, session);
     }
 
     void decorate(ModeLobbyContext ctx, PlayerInventory inventory) {
         if (ctx == null || inventory == null) return;
         PlayerSession session = ctx.session();
         if (session == null || session.state() != PlayerState.HUB) return;
-        if (state.phase != StealPhase.LOBBY && state.phase != StealPhase.START_COUNTDOWN) return;
+        if (!isWaitingPhase()) return;
 
-        decorateWaitingInventory(session, inventory, countReadyOnline(), requiredReadyPlayers());
+        readyController.decorateWaitingInventory(session, inventory);
+    }
+
+    private boolean isWaitingPhase() {
+        return state.phase == StealPhase.LOBBY || state.phase == StealPhase.START_COUNTDOWN;
     }
 
     boolean acceptsInput(PlayerSession session) {
         if (session == null) return false;
-        if (session.state() == PlayerState.HUB
-                && (state.phase == StealPhase.LOBBY || state.phase == StealPhase.START_COUNTDOWN)) {
-            return true;
-        }
+        if (session.state() == PlayerState.HUB && isWaitingPhase()) return true;
         return session.state() == PlayerState.IN_GAME
                 && state.phase == StealPhase.CHOOSE_JOB
                 && StealPlayerState.participant(session);

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLobbyUi.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLobbyUi.java
@@ -1,0 +1,83 @@
+package top.ourisland.creepersiarena.game.mode.impl.steal.runtime;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.PlayerInventory;
+import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
+import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
+import top.ourisland.creepersiarena.api.game.player.PlayerState;
+import top.ourisland.creepersiarena.config.ConfigManager;
+import top.ourisland.creepersiarena.game.lobby.item.LobbyItemService;
+
+/**
+ * Steal-owned lobby presentation.
+ * <p>
+ * Core still provides the low-level inventory clearing and the generic two-team cycle button, while the ready control
+ * is owned and marked by steal so it cannot be confused with enter-game actions.
+ */
+final class StealLobbyUi {
+
+    private final GameRuntime runtime;
+    private final StealState state;
+    private final LobbyItemService lobbyItems;
+    private final ConfigManager configManager;
+    private final StealReadyItemCodec readyItems = new StealReadyItemCodec();
+
+    StealLobbyUi(GameRuntime runtime, StealState state) {
+        this.runtime = runtime;
+        this.state = state;
+        this.lobbyItems = runtime.requireService(LobbyItemService.class);
+        this.configManager = runtime.requireService(ConfigManager.class);
+    }
+
+    void refreshWaiting(Player player, PlayerSession session) {
+        refreshWaiting(player, session, countReadyOnline(), requiredReadyPlayers());
+    }
+
+    void refreshWaiting(Player player, PlayerSession session, int ready, int required) {
+        if (player == null || session == null || session.state() != PlayerState.HUB) return;
+        if (state.phase != StealPhase.LOBBY && state.phase != StealPhase.START_COUNTDOWN) return;
+
+        lobbyItems.applyHubKit(player, session, configManager.globalConfig(), 2, false);
+        decorateWaitingInventory(session, player.getInventory(), ready, required);
+    }
+
+    int countReadyOnline() {
+        int count = 0;
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            PlayerSession session = runtime.sessionStore().get(player);
+            if (StealPlayerState.ready(session)) count++;
+        }
+        return count;
+    }
+
+    int requiredReadyPlayers() {
+        return state.modeConfig().requiredReadyPlayers(Bukkit.getOnlinePlayers().size());
+    }
+
+    private void decorateWaitingInventory(PlayerSession session, PlayerInventory inventory, int ready, int required) {
+        inventory.setItem(0, readyItems.readyButton(StealPlayerState.ready(session), ready, required));
+    }
+
+    void decorate(ModeLobbyContext ctx, PlayerInventory inventory) {
+        if (ctx == null || inventory == null) return;
+        PlayerSession session = ctx.session();
+        if (session == null || session.state() != PlayerState.HUB) return;
+        if (state.phase != StealPhase.LOBBY && state.phase != StealPhase.START_COUNTDOWN) return;
+
+        decorateWaitingInventory(session, inventory, countReadyOnline(), requiredReadyPlayers());
+    }
+
+    boolean acceptsInput(PlayerSession session) {
+        if (session == null) return false;
+        if (session.state() == PlayerState.HUB
+                && (state.phase == StealPhase.LOBBY || state.phase == StealPhase.START_COUNTDOWN)) {
+            return true;
+        }
+        return session.state() == PlayerState.IN_GAME
+                && state.phase == StealPhase.CHOOSE_JOB
+                && StealPlayerState.participant(session);
+    }
+
+}

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLogicFactory.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLogicFactory.java
@@ -18,10 +18,11 @@ public final class StealLogicFactory {
         var modeConfig = StealModeConfig.from(runtime.cfg());
         var arenaConfig = StealArenaConfig.from(session.arena());
         var state = new StealState(modeConfig, arenaConfig);
+        var lobbyUi = new StealLobbyUi(runtime, state);
         return new ModeLogic(
                 new StealRules(runtime, session, state),
-                new StealTimeline(runtime, session, state),
-                new StealPlayerFlow(runtime, state)
+                new StealTimeline(runtime, session, state, lobbyUi),
+                new StealPlayerFlow(runtime, state, lobbyUi)
         );
     }
 

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLogicFactory.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLogicFactory.java
@@ -18,7 +18,8 @@ public final class StealLogicFactory {
         var modeConfig = StealModeConfig.from(runtime.cfg());
         var arenaConfig = StealArenaConfig.from(session.arena());
         var state = new StealState(modeConfig, arenaConfig);
-        var lobbyUi = new StealLobbyUi(runtime, state);
+        var readyController = new StealReadyController(runtime, state);
+        var lobbyUi = new StealLobbyUi(state, readyController);
         return new ModeLogic(
                 new StealRules(runtime, session, state),
                 new StealTimeline(runtime, session, state, lobbyUi),

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLogicFactory.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealLogicFactory.java
@@ -3,6 +3,8 @@ package top.ourisland.creepersiarena.game.mode.impl.steal.runtime;
 import top.ourisland.creepersiarena.api.game.GameSession;
 import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
 import top.ourisland.creepersiarena.api.game.mode.ModeLogic;
+import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealArenaConfig;
+import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealModeConfig;
 
 /**
  * Builds the collaborating runtime objects for one steal-mode game session.
@@ -13,7 +15,9 @@ public final class StealLogicFactory {
     }
 
     public static ModeLogic create(GameSession session, GameRuntime runtime) {
-        var state = new StealState();
+        var modeConfig = StealModeConfig.from(runtime.cfg());
+        var arenaConfig = StealArenaConfig.from(session.arena());
+        var state = new StealState(modeConfig, arenaConfig);
         return new ModeLogic(
                 new StealRules(runtime, session, state),
                 new StealTimeline(runtime, session, state),

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealPlayerFlow.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealPlayerFlow.java
@@ -13,8 +13,10 @@ import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
 import top.ourisland.creepersiarena.api.game.mode.IModePlayerFlow;
 import top.ourisland.creepersiarena.api.game.mode.context.ModeLobbyContext;
 import top.ourisland.creepersiarena.api.game.mode.context.ModePlayerContext;
+import top.ourisland.creepersiarena.api.game.player.PlayerState;
+import top.ourisland.creepersiarena.config.ConfigManager;
 import top.ourisland.creepersiarena.defaultcontent.DefaultLoadoutService;
-import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealModeConfig;
+import top.ourisland.creepersiarena.game.lobby.item.LobbyItemService;
 import top.ourisland.creepersiarena.game.mode.impl.steal.model.StealTeam;
 import top.ourisland.creepersiarena.job.JobManager;
 import top.ourisland.creepersiarena.job.skill.SkillTickTask;
@@ -29,18 +31,20 @@ import java.util.List;
  */
 final class StealPlayerFlow implements IModePlayerFlow {
 
-    private final GameRuntime runtime;
     private final DefaultLoadoutService kit;
+    private final LobbyItemService lobbyItems;
+    private final ConfigManager configManager;
     private final StealState state;
 
     StealPlayerFlow(GameRuntime runtime, StealState state) {
-        this.runtime = runtime;
         this.kit = new DefaultLoadoutService(
                 runtime.requireService(JobManager.class),
                 runtime.requireService(SkillRegistry.class),
                 runtime.requireService(SkillHotbarRenderer.class),
                 runtime.requireService(SkillTickTask.class)::nowTick
         );
+        this.lobbyItems = runtime.requireService(LobbyItemService.class);
+        this.configManager = runtime.requireService(ConfigManager.class);
         this.state = state;
     }
 
@@ -66,14 +70,41 @@ final class StealPlayerFlow implements IModePlayerFlow {
     }
 
     @Override
+    public boolean showJobSelector(ModeLobbyContext ctx) {
+        if (ctx == null || ctx.session() == null) return false;
+        return switch (state.phase) {
+            case CHOOSE_JOB -> StealPlayerState.participant(ctx.session())
+                    && ctx.session().state() == PlayerState.IN_GAME;
+            case LOBBY, START_COUNTDOWN -> state.modeConfig().allowLobbyJobSelection()
+                    && ctx.session().state() == PlayerState.HUB;
+            case SPECTATOR_TOUR, ROUND_PLAYING, ROUND_CELEBRATION, GAME_END_CELEBRATION ->
+                    state.modeConfig().allowRespawnJobSelection()
+                            && ctx.session().state() == PlayerState.RESPAWN;
+        };
+    }
+
+    @Override
+    public boolean allowJobSelection(ModeLobbyContext ctx) {
+        return showJobSelector(ctx);
+    }
+
+    @Override
     public void onEnterGame(ModePlayerContext ctx) {
         var player = ctx.player();
-        player.setGameMode(GameMode.ADVENTURE);
+
+        if (state.phase == StealPhase.CHOOSE_JOB) {
+            player.setGameMode(GameMode.ADVENTURE);
+            lobbyItems.applyJobSelectionKit(player, ctx.session(), configManager.globalConfig());
+            Msg.actionBar(player, Component.text("请选择本轮职业", NamedTextColor.AQUA));
+            return;
+        }
+
+        player.setGameMode(state.phase == StealPhase.ROUND_PLAYING ? GameMode.SURVIVAL : GameMode.ADVENTURE);
         kit.apply(player, ctx.session());
 
         StealTeam team = state.team(player.getUniqueId());
         if (team == StealTeam.BLUE) {
-            player.getInventory().setItem(6, bluePickaxe(StealModeConfig.from(runtime.cfg()).mineCooldownSeconds()));
+            player.getInventory().setItem(6, bluePickaxe(state.modeConfig().mineCooldownSeconds()));
         }
 
         if (team == null) {

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealPlayerFlow.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealPlayerFlow.java
@@ -104,6 +104,14 @@ final class StealPlayerFlow implements IModePlayerFlow {
     }
 
     @Override
+    public boolean allowGameplaySkillRuntime(ModePlayerContext ctx) {
+        if (ctx == null || ctx.session() == null || ctx.player() == null) return false;
+        return state.phase == StealPhase.ROUND_PLAYING
+                && StealPlayerState.participant(ctx.session())
+                && state.isAlive(ctx.player().getUniqueId());
+    }
+
+    @Override
     public void onEnterGame(ModePlayerContext ctx) {
         var player = ctx.player();
 

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealPlayerFlow.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealPlayerFlow.java
@@ -5,6 +5,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -32,18 +33,18 @@ import java.util.List;
 final class StealPlayerFlow implements IModePlayerFlow {
 
     private final DefaultLoadoutService kit;
-    private final LobbyItemService lobbyItems;
+    private final StealLobbyUi lobbyUi;
     private final ConfigManager configManager;
     private final StealState state;
 
-    StealPlayerFlow(GameRuntime runtime, StealState state) {
+    StealPlayerFlow(GameRuntime runtime, StealState state, StealLobbyUi lobbyUi) {
         this.kit = new DefaultLoadoutService(
                 runtime.requireService(JobManager.class),
                 runtime.requireService(SkillRegistry.class),
                 runtime.requireService(SkillHotbarRenderer.class),
                 runtime.requireService(SkillTickTask.class)::nowTick
         );
-        this.lobbyItems = runtime.requireService(LobbyItemService.class);
+        this.lobbyUi = lobbyUi;
         this.configManager = runtime.requireService(ConfigManager.class);
         this.state = state;
     }
@@ -64,9 +65,13 @@ final class StealPlayerFlow implements IModePlayerFlow {
     }
 
     @Override
-    public int selectableTeamCount(ModeLobbyContext ctx) {
-        if (state.phase == StealPhase.LOBBY || state.phase == StealPhase.START_COUNTDOWN) return 2;
-        return 0;
+    public boolean allowHubEntrance(ModeLobbyContext ctx) {
+        return false;
+    }
+
+    @Override
+    public boolean acceptsLobbyUiInput(ModeLobbyContext ctx) {
+        return ctx != null && lobbyUi.acceptsInput(ctx.session());
     }
 
     @Override
@@ -75,12 +80,22 @@ final class StealPlayerFlow implements IModePlayerFlow {
         return switch (state.phase) {
             case CHOOSE_JOB -> StealPlayerState.participant(ctx.session())
                     && ctx.session().state() == PlayerState.IN_GAME;
-            case LOBBY, START_COUNTDOWN -> state.modeConfig().allowLobbyJobSelection()
-                    && ctx.session().state() == PlayerState.HUB;
+            case LOBBY, START_COUNTDOWN -> false;
             case SPECTATOR_TOUR, ROUND_PLAYING, ROUND_CELEBRATION, GAME_END_CELEBRATION ->
                     state.modeConfig().allowRespawnJobSelection()
                             && ctx.session().state() == PlayerState.RESPAWN;
         };
+    }
+
+    @Override
+    public int selectableTeamCount(ModeLobbyContext ctx) {
+        if (state.phase == StealPhase.LOBBY || state.phase == StealPhase.START_COUNTDOWN) return 2;
+        return 0;
+    }
+
+    @Override
+    public void decorateLobbyInventory(ModeLobbyContext ctx, org.bukkit.inventory.PlayerInventory inventory) {
+        lobbyUi.decorate(ctx, inventory);
     }
 
     @Override
@@ -94,12 +109,24 @@ final class StealPlayerFlow implements IModePlayerFlow {
 
         if (state.phase == StealPhase.CHOOSE_JOB) {
             player.setGameMode(GameMode.ADVENTURE);
-            lobbyItems.applyJobSelectionKit(player, ctx.session(), configManager.globalConfig());
+            player.getInventory().clear();
+            player.getInventory().setArmorContents(null);
+            player.getInventory().setItemInOffHand(null);
+            runtimeApplyJobSelectionKit(player, ctx);
             Msg.actionBar(player, Component.text("请选择本轮职业", NamedTextColor.AQUA));
             return;
         }
 
-        player.setGameMode(state.phase == StealPhase.ROUND_PLAYING ? GameMode.SURVIVAL : GameMode.ADVENTURE);
+        if (state.phase != StealPhase.ROUND_PLAYING) {
+            player.setGameMode(GameMode.ADVENTURE);
+            player.getInventory().clear();
+            player.getInventory().setArmorContents(null);
+            player.getInventory().setItemInOffHand(null);
+            Msg.actionBar(player, Component.text("等待偷窃模式阶段切换", NamedTextColor.GRAY));
+            return;
+        }
+
+        player.setGameMode(GameMode.ADVENTURE);
         kit.apply(player, ctx.session());
 
         StealTeam team = state.team(player.getUniqueId());
@@ -108,12 +135,17 @@ final class StealPlayerFlow implements IModePlayerFlow {
         }
 
         if (team == null) {
-            Msg.actionBar(player, Component.text("进入游戏", NamedTextColor.GREEN));
+            Msg.actionBar(player, Component.text("进入偷窃回合", NamedTextColor.GREEN));
             return;
         }
 
         Msg.actionBar(player, Component.text("你是", NamedTextColor.WHITE)
                 .append(Component.text(team.displayNameZh(), team.color())));
+    }
+
+    private void runtimeApplyJobSelectionKit(Player player, ModePlayerContext ctx) {
+        var lobbyItems = ctx.runtime().requireService(LobbyItemService.class);
+        lobbyItems.applyJobSelectionKit(player, ctx.session(), configManager.globalConfig());
     }
 
     private ItemStack bluePickaxe(int cooldownSeconds) {

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealReadyController.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealReadyController.java
@@ -1,0 +1,119 @@
+package top.ourisland.creepersiarena.game.mode.impl.steal.runtime;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import top.ourisland.creepersiarena.api.game.GameSession;
+import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
+import top.ourisland.creepersiarena.api.game.player.PlayerState;
+import top.ourisland.creepersiarena.config.ConfigManager;
+import top.ourisland.creepersiarena.game.lobby.item.LobbyItemService;
+import top.ourisland.creepersiarena.utils.Msg;
+
+/**
+ * Owns steal's waiting ready control: state transitions, item detection, and inventory rendering.
+ */
+final class StealReadyController {
+
+    private final GameRuntime runtime;
+    private final StealState state;
+    private final LobbyItemService lobbyItems;
+    private final ConfigManager configManager;
+    private final StealReadyItemCodec readyItems = new StealReadyItemCodec();
+
+    StealReadyController(GameRuntime runtime, StealState state) {
+        this.runtime = runtime;
+        this.state = state;
+        this.lobbyItems = runtime.requireService(LobbyItemService.class);
+        this.configManager = runtime.requireService(ConfigManager.class);
+    }
+
+    boolean isReadyButton(ItemStack item) {
+        return readyItems.isReadyButton(item);
+    }
+
+    void refreshWaiting(Player player, PlayerSession session) {
+        refreshWaiting(player, session, countReadyOnline(), requiredReadyPlayers());
+    }
+
+    void refreshWaiting(
+            Player player,
+            PlayerSession session,
+            int ready,
+            int required
+    ) {
+        if (player == null || session == null || session.state() != PlayerState.HUB) return;
+        if (!isWaitingPhase()) return;
+
+        lobbyItems.applyHubKit(player, session, configManager.globalConfig(), 2, false);
+        decorateWaitingInventory(session, player.getInventory(), ready, required);
+    }
+
+    int countReadyOnline() {
+        int count = 0;
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            PlayerSession session = runtime.sessionStore().get(player);
+            if (StealPlayerState.ready(session)) count++;
+        }
+        return count;
+    }
+
+    int requiredReadyPlayers() {
+        return state.modeConfig().requiredReadyPlayers(Bukkit.getOnlinePlayers().size());
+    }
+
+    private boolean isWaitingPhase() {
+        return state.phase == StealPhase.LOBBY || state.phase == StealPhase.START_COUNTDOWN;
+    }
+
+    void decorateWaitingInventory(
+            PlayerSession session,
+            PlayerInventory inventory,
+            int ready,
+            int required
+    ) {
+        if (session == null || inventory == null || !isWaitingPhase()) return;
+        inventory.setItem(0, readyItems.readyButton(StealPlayerState.ready(session), ready, required));
+    }
+
+    void decorateWaitingInventory(PlayerSession session, PlayerInventory inventory) {
+        decorateWaitingInventory(session, inventory, countReadyOnline(), requiredReadyPlayers());
+    }
+
+    boolean toggleReady(Player player, GameSession game) {
+        if (player == null || game == null) return false;
+        PlayerSession session = runtime.sessionStore().getOrCreate(player);
+        if (!canToggleReady(session)) {
+            Msg.actionBar(player, Component.text("当前阶段不能切换准备", NamedTextColor.RED));
+            return false;
+        }
+
+        boolean next = !StealPlayerState.ready(session);
+        StealPlayerState.ready(session, next);
+        StealPlayerState.participant(session, false);
+        StealPlayerState.alive(session, false);
+        if (!game.players().contains(player.getUniqueId())) {
+            game.addPlayer(player.getUniqueId());
+        }
+
+        decorateWaitingInventory(session, player.getInventory(), countReadyOnline(), requiredReadyPlayers());
+        player.playSound(player, next
+                ? Sound.BLOCK_NOTE_BLOCK_PLING
+                : Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, SoundCategory.PLAYERS, 1.0f, next ? 2.0f : 1.0f);
+        Msg.actionBar(player, next
+                ? Component.text("✪ 你已准备加入偷窃模式", NamedTextColor.GREEN)
+                : Component.text("✪ 你取消了准备", NamedTextColor.GRAY));
+        return true;
+    }
+
+    private boolean canToggleReady(PlayerSession session) {
+        return session != null && session.state() == PlayerState.HUB && isWaitingPhase();
+    }
+
+}

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealReadyController.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealReadyController.java
@@ -51,8 +51,14 @@ final class StealReadyController {
         if (player == null || session == null || session.state() != PlayerState.HUB) return;
         if (!isWaitingPhase()) return;
 
-        lobbyItems.applyHubKit(player, session, configManager.globalConfig(), 2, false);
-        decorateWaitingInventory(session, player.getInventory(), ready, required);
+        PlayerInventory inventory = player.getInventory();
+        ItemStack desired = readyItems.readyButton(StealPlayerState.ready(session), ready, required);
+        if (!readyItems.isReadyButton(inventory.getItem(0))) {
+            lobbyItems.applyHubKit(player, session, configManager.globalConfig(), 2, false);
+        }
+        if (!desired.isSimilar(inventory.getItem(0))) {
+            inventory.setItem(0, desired);
+        }
     }
 
     int countReadyOnline() {
@@ -72,6 +78,10 @@ final class StealReadyController {
         return state.phase == StealPhase.LOBBY || state.phase == StealPhase.START_COUNTDOWN;
     }
 
+    void decorateWaitingInventory(PlayerSession session, PlayerInventory inventory) {
+        decorateWaitingInventory(session, inventory, countReadyOnline(), requiredReadyPlayers());
+    }
+
     void decorateWaitingInventory(
             PlayerSession session,
             PlayerInventory inventory,
@@ -80,10 +90,6 @@ final class StealReadyController {
     ) {
         if (session == null || inventory == null || !isWaitingPhase()) return;
         inventory.setItem(0, readyItems.readyButton(StealPlayerState.ready(session), ready, required));
-    }
-
-    void decorateWaitingInventory(PlayerSession session, PlayerInventory inventory) {
-        decorateWaitingInventory(session, inventory, countReadyOnline(), requiredReadyPlayers());
     }
 
     boolean toggleReady(Player player, GameSession game) {
@@ -98,8 +104,12 @@ final class StealReadyController {
         StealPlayerState.ready(session, next);
         StealPlayerState.participant(session, false);
         StealPlayerState.alive(session, false);
-        if (!game.players().contains(player.getUniqueId())) {
-            game.addPlayer(player.getUniqueId());
+        if (next) {
+            if (!game.players().contains(player.getUniqueId())) {
+                game.addPlayer(player.getUniqueId());
+            }
+        } else {
+            game.removePlayer(player.getUniqueId());
         }
 
         decorateWaitingInventory(session, player.getInventory(), countReadyOnline(), requiredReadyPlayers());

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealReadyItemCodec.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealReadyItemCodec.java
@@ -1,0 +1,54 @@
+package top.ourisland.creepersiarena.game.mode.impl.steal.runtime;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Steal-owned ready item marker and factory.
+ * <p>
+ * This deliberately does not use the generic core {@code LobbyAction} codec: ready/unready is a mode-owned waiting-room
+ * action, and {@code /join} means "ready" in steal.
+ */
+final class StealReadyItemCodec {
+
+    private static final NamespacedKey READY_ACTION_KEY = new NamespacedKey("creepersiarena", "steal_ready_action");
+    private static final String TOGGLE_READY = "toggle_ready";
+
+    ItemStack readyButton(boolean ready, int readyCount, int neededCount) {
+        ItemStack item = new ItemStack(ready ? Material.GREEN_DYE : Material.GRAY_DYE);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.displayName(ready
+                    ? Component.text("已准备：点击取消", NamedTextColor.GREEN)
+                    : Component.text("未准备：点击准备", NamedTextColor.GRAY));
+            meta.lore(List.of(
+                    Component.text("当前已准备: " + Math.max(0, readyCount) + " / 需要 " + Math.max(1, neededCount), NamedTextColor.WHITE),
+                    Component.text("/cia join 也只会切换为准备，不会传送", NamedTextColor.GRAY),
+                    Component.text("偷窃模式开局后才会进入导览/选职业/回合", NamedTextColor.DARK_GRAY)
+            ));
+            meta.setEnchantmentGlintOverride(ready);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            meta.getPersistentDataContainer().set(READY_ACTION_KEY, PersistentDataType.STRING, TOGGLE_READY);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    boolean isReadyButton(@Nullable ItemStack item) {
+        if (item == null || item.getType().isAir()) return false;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+        String action = meta.getPersistentDataContainer().get(READY_ACTION_KEY, PersistentDataType.STRING);
+        return TOGGLE_READY.equals(action);
+    }
+
+}

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealRules.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealRules.java
@@ -61,7 +61,7 @@ final class StealRules implements IModeRules {
         StealPlayerState.ready(ctx.session(), false);
         StealPlayerState.participant(ctx.session(), false);
         StealPlayerState.alive(ctx.session(), false);
-        return new JoinDecision.AttachToHub();
+        return new JoinDecision.ToHub();
     }
 
     @Override

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealRules.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealRules.java
@@ -12,6 +12,7 @@ import top.ourisland.creepersiarena.api.game.mode.GameModeType;
 import top.ourisland.creepersiarena.api.game.mode.GameRuntime;
 import top.ourisland.creepersiarena.api.game.mode.IModeRules;
 import top.ourisland.creepersiarena.api.game.mode.context.JoinContext;
+import top.ourisland.creepersiarena.api.game.mode.context.JoinSource;
 import top.ourisland.creepersiarena.api.game.mode.context.LeaveContext;
 import top.ourisland.creepersiarena.api.game.mode.context.RespawnContext;
 import top.ourisland.creepersiarena.utils.Msg;
@@ -36,7 +37,9 @@ final class StealRules implements IModeRules {
     @Override
     public JoinDecision onJoin(JoinContext ctx) {
         return switch (state.phase) {
-            case LOBBY, START_COUNTDOWN -> joinAsReady(ctx);
+            case LOBBY, START_COUNTDOWN -> ctx.source() == JoinSource.HUB_REQUEST
+                    ? joinAsReady(ctx)
+                    : attachWaitingAudience(ctx);
             case SPECTATOR_TOUR, CHOOSE_JOB, ROUND_PLAYING, ROUND_CELEBRATION, GAME_END_CELEBRATION -> {
                 Location view = game.arena().anchor().clone().add(0, 8, 0);
                 yield new JoinDecision.ToSpectate(view);
@@ -45,16 +48,19 @@ final class StealRules implements IModeRules {
     }
 
     private JoinDecision joinAsReady(JoinContext ctx) {
-        if (!ctx.fromHubRequest()) {
-            return new JoinDecision.ToHub();
-        }
-
         StealPlayerState.ready(ctx.session(), true);
         StealPlayerState.participant(ctx.session(), false);
         StealPlayerState.alive(ctx.session(), false);
 
         ctx.player().playSound(ctx.player(), Sound.BLOCK_NOTE_BLOCK_PLING, SoundCategory.PLAYERS, 1.0f, 2.0f);
-        Msg.actionBar(ctx.player(), Component.text("✪ 你已准备加入偷窃模式", NamedTextColor.GREEN));
+        Msg.actionBar(ctx.player(), Component.text("✪ 你已准备加入偷窃模式，不会立即传送", NamedTextColor.GREEN));
+        return new JoinDecision.AttachToHub();
+    }
+
+    private JoinDecision attachWaitingAudience(JoinContext ctx) {
+        StealPlayerState.ready(ctx.session(), false);
+        StealPlayerState.participant(ctx.session(), false);
+        StealPlayerState.alive(ctx.session(), false);
         return new JoinDecision.AttachToHub();
     }
 

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealRules.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealRules.java
@@ -55,7 +55,7 @@ final class StealRules implements IModeRules {
 
         ctx.player().playSound(ctx.player(), Sound.BLOCK_NOTE_BLOCK_PLING, SoundCategory.PLAYERS, 1.0f, 2.0f);
         Msg.actionBar(ctx.player(), Component.text("✪ 你已准备加入偷窃模式", NamedTextColor.GREEN));
-        return new JoinDecision.ToHub();
+        return new JoinDecision.AttachToHub();
     }
 
     @Override

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealState.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealState.java
@@ -1,5 +1,7 @@
 package top.ourisland.creepersiarena.game.mode.impl.steal.runtime;
 
+import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealArenaConfig;
+import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealModeConfig;
 import top.ourisland.creepersiarena.game.mode.impl.steal.model.StealTeam;
 
 import java.util.*;
@@ -11,6 +13,8 @@ final class StealState {
     final Set<UUID> alive = new LinkedHashSet<>();
     final Map<UUID, StealTeam> teams = new LinkedHashMap<>();
     final Map<UUID, Integer> mineCooldowns = new LinkedHashMap<>();
+    private final StealModeConfig modeConfig;
+    private final StealArenaConfig arenaConfig;
     StealPhase phase = StealPhase.LOBBY;
     int remainingSeconds;
     int roundIndex;
@@ -21,6 +25,20 @@ final class StealState {
     int tourStep = -1;
     boolean closing;
 
+    StealState(StealModeConfig modeConfig, StealArenaConfig arenaConfig) {
+        this.modeConfig = Objects.requireNonNull(modeConfig, "modeConfig");
+        this.arenaConfig = Objects.requireNonNull(arenaConfig, "arenaConfig");
+        this.targetMineCount = Math.max(1, modeConfig.targetMineCount());
+    }
+
+    StealModeConfig modeConfig() {
+        return modeConfig;
+    }
+
+    StealArenaConfig arenaConfig() {
+        return arenaConfig;
+    }
+
     void resetWholeGame() {
         phase = StealPhase.LOBBY;
         remainingSeconds = 0;
@@ -28,7 +46,7 @@ final class StealState {
         redWins = 0;
         blueWins = 0;
         minedBlocks = 0;
-        targetMineCount = 10;
+        targetMineCount = Math.max(1, modeConfig.targetMineCount());
         tourStep = -1;
         closing = false;
         participants.clear();

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
@@ -65,6 +65,11 @@ final class StealTimeline implements IModeTimeline {
         };
     }
 
+    @Override
+    public void onStop(TickContext ctx) {
+        state.bossBars.hideAllTracked();
+    }
+
     GameRuntime runtime() {
         return runtime;
     }

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
@@ -7,6 +7,7 @@ import net.kyori.adventure.title.Title;
 import org.bukkit.*;
 import org.bukkit.entity.Firework;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import top.ourisland.creepersiarena.api.game.GameSession;
@@ -70,6 +71,14 @@ final class StealTimeline implements IModeTimeline {
 
     StealState state() {
         return state;
+    }
+
+    boolean isReadyButton(ItemStack item) {
+        return lobbyUi.isReadyButton(item);
+    }
+
+    boolean toggleReady(Player player) {
+        return lobbyUi.toggleReady(player, session);
     }
 
     private List<GameAction> tickLobby(StealModeConfig cfg) {
@@ -581,13 +590,7 @@ final class StealTimeline implements IModeTimeline {
     }
 
     int countReadyOnline() {
-        int c = 0;
-        for (var p : Bukkit.getOnlinePlayers()) {
-            if (p == null || !p.isOnline()) continue;
-            var s = runtime.sessionStore().get(p);
-            if (StealPlayerState.ready(s)) c++;
-        }
-        return c;
+        return lobbyUi.countReadyOnline();
     }
 
     private List<Player> onlineParticipants() {

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
@@ -28,16 +28,19 @@ final class StealTimeline implements IModeTimeline {
     private final GameRuntime runtime;
     private final GameSession session;
     private final StealState state;
+    private final StealLobbyUi lobbyUi;
     private final Random random = new Random();
 
     StealTimeline(
             GameRuntime runtime,
             GameSession session,
-            StealState state
+            StealState state,
+            StealLobbyUi lobbyUi
     ) {
         this.runtime = runtime;
         this.session = session;
         this.state = state;
+        this.lobbyUi = lobbyUi;
     }
 
     @Override
@@ -70,12 +73,13 @@ final class StealTimeline implements IModeTimeline {
     }
 
     private List<GameAction> tickLobby(StealModeConfig cfg) {
-        var players = onlineSessionPlayers();
+        var players = onlineAudiencePlayers();
         int population = players.size();
         int ready = countReadyOnline();
         int required = cfg.requiredReadyPlayers(population);
 
-        state.bossBars.showWaiting(players, ready, required, Math.max(1, population), 0, cfg.startCountdownSeconds());
+        refreshWaitingUi(players, ready, required);
+        state.bossBars.showWaiting(players, ready, required, Math.max(required, population), 0, cfg.startCountdownSeconds());
         if (population == 0 || ready < required) return List.of();
 
         state.phase = StealPhase.START_COUNTDOWN;
@@ -95,11 +99,12 @@ final class StealTimeline implements IModeTimeline {
     }
 
     private List<GameAction> tickCountdown(StealModeConfig cfg, StealArenaConfig arenaCfg) {
-        var players = onlineSessionPlayers();
+        var players = onlineAudiencePlayers();
         int population = players.size();
         int ready = countReadyOnline();
         int required = cfg.requiredReadyPlayers(population);
-        state.bossBars.showWaiting(players, ready, required, Math.max(1, population), state.remainingSeconds, cfg.startCountdownSeconds());
+        refreshWaitingUi(players, ready, required);
+        state.bossBars.showWaiting(players, ready, required, Math.max(required, population), state.remainingSeconds, cfg.startCountdownSeconds());
 
         if (population == 0 || ready < required) {
             state.phase = StealPhase.LOBBY;
@@ -135,7 +140,8 @@ final class StealTimeline implements IModeTimeline {
         arenaCfg.resetRedstoneTargets();
         arenaCfg.setSelectionBarriers(false);
 
-        for (var p : onlineSessionPlayers()) {
+        var audience = onlineAudiencePlayers();
+        for (var p : audience) {
             p.getInventory().clear();
             p.setGameMode(GameMode.SPECTATOR);
             p.showTitle(Title.title(
@@ -145,11 +151,11 @@ final class StealTimeline implements IModeTimeline {
             p.playSound(p, Sound.BLOCK_NOTE_BLOCK_BELL, SoundCategory.PLAYERS, 1.0f, 1.0f);
         }
 
-        return List.of(new GameAction.ToSpectate(session.players(), session.arena().anchor().clone().add(0, 8, 0)));
+        return List.of(new GameAction.ToSpectate(playerIds(audience), session.arena().anchor().clone().add(0, 8, 0)));
     }
 
     private List<GameAction> tickSpectatorTour(StealModeConfig cfg, StealArenaConfig arenaCfg) {
-        var players = onlineSessionPlayers();
+        var players = onlineAudiencePlayers();
         state.bossBars.showSpectator(players, state.remainingSeconds, cfg.spectatorTourSeconds());
         showTourPointIfNeeded(arenaCfg, cfg.spectatorTourSeconds());
 
@@ -180,7 +186,7 @@ final class StealTimeline implements IModeTimeline {
 
         state.tourStep = nextStep;
         var point = points.get(nextStep);
-        for (var p : onlineSessionPlayers()) {
+        for (var p : onlineAudiencePlayers()) {
             p.teleportAsync(point.location());
             Msg.send(p, point.message());
             p.playSound(p, Sound.BLOCK_ENCHANTMENT_TABLE_USE, SoundCategory.PLAYERS, 1.0f, 0.0f);
@@ -197,7 +203,7 @@ final class StealTimeline implements IModeTimeline {
     }
 
     private void announceRoundObjective() {
-        for (var p : onlineSessionPlayers()) {
+        for (var p : onlineAudiencePlayers()) {
             var ps = runtime.sessionStore().get(p);
             var team = state.team(p.getUniqueId());
             if (!StealPlayerState.participant(ps) || team == null) continue;
@@ -273,7 +279,7 @@ final class StealTimeline implements IModeTimeline {
         state.mineCooldowns.clear();
 
         for (var p : players) {
-            p.setGameMode(GameMode.SURVIVAL);
+            p.setGameMode(GameMode.ADVENTURE);
             p.playSound(p.getLocation(), "minecraft:item.goat_horn.sound.0", SoundCategory.PLAYERS, 1.0f, 0.9f);
         }
         broadcast(Component.text("STEAL：开局！回合时长 " + state.remainingSeconds + "s", NamedTextColor.RED));
@@ -281,7 +287,7 @@ final class StealTimeline implements IModeTimeline {
     }
 
     private List<GameAction> tickRoundPlaying(StealModeConfig cfg) {
-        var players = onlineSessionPlayers();
+        var players = onlineAudiencePlayers();
         state.bossBars.showRound(players, state.remainingSeconds, cfg.timePerRoundSeconds(), state.minedBlocks, state.targetMineCount);
         state.tickMineCooldowns();
 
@@ -299,7 +305,7 @@ final class StealTimeline implements IModeTimeline {
     }
 
     private List<GameAction> tickRoundCelebration(StealModeConfig cfg, StealArenaConfig arenaCfg) {
-        var players = onlineSessionPlayers();
+        var players = onlineAudiencePlayers();
         state.bossBars.showCelebration(players, state.remainingSeconds, cfg.roundCelebrationSeconds(), false);
         launchCelebrationFireworks(3);
 
@@ -323,7 +329,7 @@ final class StealTimeline implements IModeTimeline {
     }
 
     private List<GameAction> tickGameEndCelebration(StealModeConfig cfg, StealArenaConfig arenaCfg) {
-        var players = onlineSessionPlayers();
+        var players = onlineAudiencePlayers();
         state.bossBars.showCelebration(players, state.remainingSeconds, cfg.gameEndCelebrationSeconds(), true);
         launchCelebrationFireworks(3);
 
@@ -331,8 +337,9 @@ final class StealTimeline implements IModeTimeline {
         if (state.remainingSeconds > 0) return List.of();
 
         arenaCfg.setSelectionBarriers(false);
+        Set<UUID> playersToHub = playerIds(players);
         cleanupWholeGame();
-        return List.of(new GameAction.EndGameAndBackToHub("steal finished"));
+        return List.of(new GameAction.ToHub(playersToHub));
     }
 
     boolean onMinedRedstone(Player player, StealModeConfig cfg) {
@@ -365,18 +372,34 @@ final class StealTimeline implements IModeTimeline {
     }
 
     private void broadcast(Component message) {
-        for (var p : onlineSessionPlayers()) {
+        for (var p : onlineAudiencePlayers()) {
             Msg.send(p, message);
         }
     }
 
-    private List<Player> onlineSessionPlayers() {
+    private List<Player> onlineAudiencePlayers() {
         var out = new ArrayList<Player>();
-        for (var uuid : session.players()) {
-            var p = Bukkit.getPlayer(uuid);
-            if (p != null && p.isOnline()) out.add(p);
+        for (var p : Bukkit.getOnlinePlayers()) {
+            if (p == null || !p.isOnline()) continue;
+            runtime.sessionStore().getOrCreate(p);
+            out.add(p);
         }
         return out;
+    }
+
+    private void refreshWaitingUi(Collection<Player> players, int ready, int required) {
+        for (var p : players) {
+            PlayerSession ps = runtime.sessionStore().getOrCreate(p);
+            lobbyUi.refreshWaiting(p, ps, ready, required);
+        }
+    }
+
+    private Set<UUID> playerIds(Collection<Player> players) {
+        var ids = new LinkedHashSet<UUID>();
+        for (var p : players) {
+            if (p != null) ids.add(p.getUniqueId());
+        }
+        return ids;
     }
 
     void onPlayerDeath(Player player) {
@@ -421,7 +444,7 @@ final class StealTimeline implements IModeTimeline {
 
         state.phase = StealPhase.ROUND_CELEBRATION;
         state.remainingSeconds = cfg.roundCelebrationSeconds();
-        for (var p : onlineSessionPlayers()) {
+        for (var p : onlineAudiencePlayers()) {
             p.playSound(p, Sound.ENTITY_ENDER_DRAGON_GROWL, SoundCategory.PLAYERS, 1.0f, 1.0f);
         }
         return List.of();
@@ -440,7 +463,7 @@ final class StealTimeline implements IModeTimeline {
 
         var title = Component.text(winner.displayNameZh() + "获得了胜利！", winner.color())
                 .decorate(TextDecoration.BOLD);
-        for (var p : onlineSessionPlayers()) {
+        for (var p : onlineAudiencePlayers()) {
             p.setGameMode(GameMode.ADVENTURE);
             p.showTitle(Title.title(title, Component.empty()));
             p.playSound(p, Sound.ENTITY_ENDER_DRAGON_DEATH, SoundCategory.PLAYERS, 0.7f, 1.0f);
@@ -499,15 +522,14 @@ final class StealTimeline implements IModeTimeline {
         state.teams.clear();
         state.mineCooldowns.clear();
 
-        for (var uuid : session.players()) {
-            var p = Bukkit.getPlayer(uuid);
-            if (p == null || !p.isOnline()) continue;
-
+        for (var p : onlineAudiencePlayers()) {
             var ps = runtime.sessionStore().getOrCreate(p);
             boolean participant = StealPlayerState.ready(ps);
             StealPlayerState.participant(ps, participant);
             StealPlayerState.alive(ps, participant);
             if (participant) {
+                UUID uuid = p.getUniqueId();
+                session.addPlayer(uuid);
                 state.participants.add(uuid);
                 state.alive.add(uuid);
             }
@@ -558,10 +580,9 @@ final class StealTimeline implements IModeTimeline {
                 .append(Component.text(team.displayNameZh(), team.color())));
     }
 
-    private int countReadyOnline() {
+    int countReadyOnline() {
         int c = 0;
-        for (var uuid : session.players()) {
-            var p = Bukkit.getPlayer(uuid);
+        for (var p : Bukkit.getOnlinePlayers()) {
             if (p == null || !p.isOnline()) continue;
             var s = runtime.sessionStore().get(p);
             if (StealPlayerState.ready(s)) c++;
@@ -584,7 +605,7 @@ final class StealTimeline implements IModeTimeline {
             Sound sound,
             float pitch
     ) {
-        for (var p : onlineSessionPlayers()) {
+        for (var p : onlineAudiencePlayers()) {
             p.playSound(p, sound, SoundCategory.PLAYERS, 1.0f, pitch);
         }
         broadcast(Component.text("还剩" + formatTime(remaining), color));
@@ -600,7 +621,7 @@ final class StealTimeline implements IModeTimeline {
         int launched = 0;
         for (var p : onlineParticipants()) {
             if (launched >= limit) return;
-            if (p.getGameMode() != GameMode.ADVENTURE && p.getGameMode() != GameMode.SURVIVAL) continue;
+            if (p.getGameMode() != GameMode.ADVENTURE) continue;
             spawnFirework(p.getLocation().clone().add(0, 1.5, 0));
             launched++;
         }
@@ -626,7 +647,7 @@ final class StealTimeline implements IModeTimeline {
     }
 
     private void cleanupWholeGame() {
-        for (var p : onlineSessionPlayers()) {
+        for (var p : onlineAudiencePlayers()) {
             var ps = runtime.sessionStore().get(p);
             StealPlayerState.clear(ps);
             p.getInventory().clear();

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
@@ -47,8 +47,8 @@ final class StealTimeline implements IModeTimeline {
 
     @Override
     public List<GameAction> tick(TickContext ctx) {
-        var cfg = StealModeConfig.from(runtime.cfg());
-        var arenaCfg = StealArenaConfig.from(session.arena());
+        var cfg = state.modeConfig();
+        var arenaCfg = state.arenaConfig();
 
         return switch (state.phase) {
             case LOBBY -> tickLobby(cfg);
@@ -277,7 +277,7 @@ final class StealTimeline implements IModeTimeline {
             p.playSound(p.getLocation(), "minecraft:item.goat_horn.sound.0", SoundCategory.PLAYERS, 1.0f, 0.9f);
         }
         broadcast(Component.text("STEAL：开局！回合时长 " + state.remainingSeconds + "s", NamedTextColor.RED));
-        return List.of();
+        return List.of(new GameAction.EnterGame(new LinkedHashSet<>(state.participants)));
     }
 
     private List<GameAction> tickRoundPlaying(StealModeConfig cfg) {
@@ -416,7 +416,7 @@ final class StealTimeline implements IModeTimeline {
 
         boolean finalGame = state.wins(winner) >= cfg.scoreToWin() || state.roundIndex >= cfg.totalRound();
         if (finalGame) {
-            return startFinalCelebration(cfg, StealArenaConfig.from(session.arena()), winner, reason);
+            return startFinalCelebration(cfg, state.arenaConfig(), winner, reason);
         }
 
         state.phase = StealPhase.ROUND_CELEBRATION;

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
@@ -389,17 +389,15 @@ final class StealTimeline implements IModeTimeline {
     private List<Player> onlineAudiencePlayers() {
         var out = new ArrayList<Player>();
         for (var p : Bukkit.getOnlinePlayers()) {
-            if (p == null || !p.isOnline()) continue;
-            runtime.sessionStore().getOrCreate(p);
-            out.add(p);
+            if (p != null && p.isOnline()) out.add(p);
         }
         return out;
     }
 
     private void refreshWaitingUi(Collection<Player> players, int ready, int required) {
         for (var p : players) {
-            PlayerSession ps = runtime.sessionStore().getOrCreate(p);
-            lobbyUi.refreshWaiting(p, ps, ready, required);
+            PlayerSession ps = runtime.sessionStore().get(p);
+            if (ps != null) lobbyUi.refreshWaiting(p, ps, ready, required);
         }
     }
 
@@ -532,7 +530,8 @@ final class StealTimeline implements IModeTimeline {
         state.mineCooldowns.clear();
 
         for (var p : onlineAudiencePlayers()) {
-            var ps = runtime.sessionStore().getOrCreate(p);
+            var ps = runtime.sessionStore().get(p);
+            if (ps == null) continue;
             boolean participant = StealPlayerState.ready(ps);
             StealPlayerState.participant(ps, participant);
             StealPlayerState.alive(ps, participant);
@@ -582,7 +581,8 @@ final class StealTimeline implements IModeTimeline {
     }
 
     private void applyTeam(Player p, StealTeam team) {
-        var ps = runtime.sessionStore().getOrCreate(p);
+        var ps = runtime.sessionStore().get(p);
+        if (ps == null) return;
         StealPlayerState.team(ps, team);
         state.setTeam(p.getUniqueId(), team);
         Msg.send(p, Component.text("你加入了", NamedTextColor.WHITE)

--- a/cia-default-content/src/main/resources/default-content/config.yml
+++ b/cia-default-content/src/main/resources/default-content/config.yml
@@ -2,12 +2,20 @@ game:
   default-mode: battle
   modes:
     battle:
-      single-game-time: 600
-      respawn-time: 10
+      respawn-time: 8
       leave-in-game-time: 5
       max-team: 4
       team-auto-balancing: true
       force-balancing: false
+      entrance-enabled: true
+      map-progress-target: 4000
+      kill-progress:
+        "1-2": 100
+        "3-4": 75
+        "5-7": 60
+        "8-10": 45
+        "11-14": 30
+        "15+": 20
 
     steal:
       min-player-to-start: 2

--- a/cia-default-content/src/main/resources/default-content/config.yml
+++ b/cia-default-content/src/main/resources/default-content/config.yml
@@ -19,6 +19,8 @@ game:
       time-per-round: 180
       target-mine-count: 10
       mine-cooldown-seconds: 3
+      allow-lobby-job-selection: false
+      allow-respawn-job-selection: false
       score-to-win: 4
       round-celebration-time: 5
       game-end-celebration-time: 10

--- a/cia-default-content/src/test/java/top/ourisland/creepersiarena/game/mode/impl/battle/config/BattleModeConfigTest.java
+++ b/cia-default-content/src/test/java/top/ourisland/creepersiarena/game/mode/impl/battle/config/BattleModeConfigTest.java
@@ -16,6 +16,10 @@ class BattleModeConfigTest {
         yaml.set("game.modes.battle.max-team", 6);
         yaml.set("game.modes.battle.team-auto-balancing", false);
         yaml.set("game.modes.battle.force-balancing", true);
+        yaml.set("game.modes.battle.map-progress-target", 2500);
+        yaml.set("game.modes.battle.entrance-enabled", false);
+        yaml.set("game.modes.battle.kill-progress.1-2", 50);
+        yaml.set("game.modes.battle.kill-progress.3-4", 25);
 
         var config = BattleModeConfig.from(fromYaml(yaml));
 
@@ -24,8 +28,11 @@ class BattleModeConfigTest {
         assertEquals(6, config.maxTeam());
         assertFalse(config.teamAutoBalancing());
         assertTrue(config.forceBalancing());
+        assertEquals(2500, config.mapProgressTarget());
+        assertFalse(config.entranceEnabled());
+        assertEquals(50, config.killProgressForPopulation(2));
+        assertEquals(25, config.killProgressForPopulation(4));
     }
-
 
     @Test
     void usesDefaultsAndClampsInvalidTeamCount() {
@@ -35,10 +42,18 @@ class BattleModeConfigTest {
         var config = BattleModeConfig.from(fromYaml(yaml));
 
         assertEquals(600, config.singleGameTimeSeconds());
-        assertEquals(10, config.respawnTimeSeconds());
+        assertEquals(8, config.respawnTimeSeconds());
         assertEquals(1, config.maxTeam());
         assertTrue(config.teamAutoBalancing());
         assertFalse(config.forceBalancing());
+        assertEquals(4000, config.mapProgressTarget());
+        assertTrue(config.entranceEnabled());
+        assertEquals(100, config.killProgressForPopulation(2));
+        assertEquals(75, config.killProgressForPopulation(4));
+        assertEquals(60, config.killProgressForPopulation(7));
+        assertEquals(45, config.killProgressForPopulation(10));
+        assertEquals(30, config.killProgressForPopulation(14));
+        assertEquals(20, config.killProgressForPopulation(15));
     }
 
 }

--- a/cia-default-content/src/test/java/top/ourisland/creepersiarena/game/mode/impl/steal/config/StealModeConfigTest.java
+++ b/cia-default-content/src/test/java/top/ourisland/creepersiarena/game/mode/impl/steal/config/StealModeConfigTest.java
@@ -4,6 +4,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static top.ourisland.creepersiarena.api.testsupport.TestGameConfigViews.fromYaml;
 
 class StealModeConfigTest {
@@ -23,6 +24,8 @@ class StealModeConfigTest {
         yaml.set("game.modes.steal.score-to-win", 2);
         yaml.set("game.modes.steal.round-celebration-time", 4);
         yaml.set("game.modes.steal.game-end-celebration-time", 9);
+        yaml.set("game.modes.steal.allow-lobby-job-selection", true);
+        yaml.set("game.modes.steal.allow-respawn-job-selection", true);
 
         var config = StealModeConfig.from(fromYaml(yaml));
 
@@ -38,6 +41,8 @@ class StealModeConfigTest {
         assertEquals(2, config.scoreToWin());
         assertEquals(4, config.roundCelebrationSeconds());
         assertEquals(9, config.gameEndCelebrationSeconds());
+        assertTrue(config.allowLobbyJobSelection());
+        assertTrue(config.allowRespawnJobSelection());
     }
 
     @Test
@@ -78,7 +83,7 @@ class StealModeConfigTest {
 
     @Test
     void scalesReadyRequirementFromJoinedPlayerCountLikeTheDatapackSurfaceBehavior() {
-        var config = new StealModeConfig(2, true, 15, 11, 10, 7, 180, 10, 4, 5, 10, 3);
+        var config = new StealModeConfig(2, true, 15, 11, 10, 7, 180, 10, 4, 5, 10, 3, false, false);
 
         assertEquals(2, config.requiredReadyPlayers(2));
         assertEquals(3, config.requiredReadyPlayers(5));

--- a/cia-default-content/src/test/java/top/ourisland/creepersiarena/game/mode/impl/steal/config/StealModeConfigTest.java
+++ b/cia-default-content/src/test/java/top/ourisland/creepersiarena/game/mode/impl/steal/config/StealModeConfigTest.java
@@ -79,12 +79,14 @@ class StealModeConfigTest {
         assertEquals(1, config.totalRound());
         assertEquals(1, config.timePerRoundSeconds());
         assertEquals(0, config.mineCooldownSeconds());
+        assertEquals(2, config.requiredReadyPlayers(1));
     }
 
     @Test
     void scalesReadyRequirementFromJoinedPlayerCountLikeTheDatapackSurfaceBehavior() {
         var config = new StealModeConfig(2, true, 15, 11, 10, 7, 180, 10, 4, 5, 10, 3, false, false);
 
+        assertEquals(2, config.requiredReadyPlayers(1));
         assertEquals(2, config.requiredReadyPlayers(2));
         assertEquals(3, config.requiredReadyPlayers(5));
         assertEquals(5, config.requiredReadyPlayers(9));

--- a/cia-default-content/src/test/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealStateTest.java
+++ b/cia-default-content/src/test/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealStateTest.java
@@ -1,0 +1,82 @@
+package top.ourisland.creepersiarena.game.mode.impl.steal.runtime;
+
+import org.junit.jupiter.api.Test;
+import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealArenaConfig;
+import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealModeConfig;
+import top.ourisland.creepersiarena.game.mode.impl.steal.model.StealTeam;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StealStateTest {
+
+    @Test
+    void tracksParticipantsTeamsAliveAndCooldownsWithoutBukkitRuntime() {
+        var state = state();
+        UUID red = UUID.randomUUID();
+        UUID blue = UUID.randomUUID();
+
+        state.participants.add(red);
+        state.participants.add(blue);
+        state.alive.add(red);
+        state.alive.add(blue);
+        state.setTeam(red, StealTeam.RED);
+        state.setTeam(blue, StealTeam.BLUE);
+        state.startMineCooldown(blue, 2);
+
+        assertTrue(state.isParticipant(red));
+        assertEquals(1, state.participantsOn(StealTeam.RED));
+        assertEquals(1, state.livingOn(StealTeam.BLUE));
+        assertEquals(2, state.mineCooldown(blue));
+
+        state.tickMineCooldowns();
+        assertEquals(1, state.mineCooldown(blue));
+        state.tickMineCooldowns();
+        assertEquals(0, state.mineCooldown(blue));
+
+        state.markDead(red);
+        assertFalse(state.isAlive(red));
+        assertEquals(0, state.livingOn(StealTeam.RED));
+    }
+
+    private StealState state() {
+        return new StealState(
+                new StealModeConfig(2, true, 15, 11, 10, 7, 180, 10, 4, 5, 10, 3, false, false),
+                new StealArenaConfig(List.of(), List.of(), List.of())
+        );
+    }
+
+    @Test
+    void wholeGameResetClearsModeOwnedRuntimeCollections() {
+        var state = state();
+        UUID player = UUID.randomUUID();
+        state.phase = StealPhase.ROUND_PLAYING;
+        state.remainingSeconds = 99;
+        state.roundIndex = 3;
+        state.redWins = 2;
+        state.blueWins = 1;
+        state.minedBlocks = 7;
+        state.targetMineCount = 3;
+        state.participants.add(player);
+        state.alive.add(player);
+        state.setTeam(player, StealTeam.BLUE);
+        state.startMineCooldown(player, 3);
+
+        state.resetWholeGame();
+
+        assertEquals(StealPhase.LOBBY, state.phase);
+        assertEquals(0, state.remainingSeconds);
+        assertEquals(0, state.roundIndex);
+        assertEquals(0, state.redWins);
+        assertEquals(0, state.blueWins);
+        assertEquals(0, state.minedBlocks);
+        assertEquals(10, state.targetMineCount);
+        assertTrue(state.participants.isEmpty());
+        assertTrue(state.alive.isEmpty());
+        assertTrue(state.teams.isEmpty());
+        assertTrue(state.mineCooldowns.isEmpty());
+    }
+
+}


### PR DESCRIPTION
close: #41

## Summary by Sourcery

Refine core game flow and mode APIs to support mode-specific lobby behaviour, battle map progression, and steal-mode ready/waiting UX, while tightening attachment of players to active sessions and improving cleanup when games end or rotate.

New Features:
- Introduce mode hooks for controlling hub entrance, lobby UI handling, job selection, and gameplay skill runtime, and expose them through centralized lobby hook utilities.
- Add configurable battle-mode progression based on per-kill map progress, with boss bars, team balancing, PvP rules, and automatic arena rotation when the map is complete.
- Implement steal-mode ready/waiting controls and lobby UI, including a ready button item, mode-owned waiting inventory, and flexible job selection phases.

Bug Fixes:
- Ensure players are correctly attached to and detached from active game sessions across hub, spectate, and system-driven transitions.
- Fix steal-mode redstone mining and audience handling so interactions and teleport actions respect the current phase and player readiness.
- Prevent skill runtime and lobby UI listeners from acting on players or states where the active mode does not accept those interactions.

Enhancements:
- Refine join/leave flow with richer join sources, attach-to-hub decisions, and a SYSTEM leave reason used by game actions and rotation.
- Extend battle and steal mode configs with additional tuning options and clamp logic, and update timelines to clean up boss bars via the new onStop hook.
- Update lobby item service and stage/lobby transitions to respect mode-owned decisions about when to render job selectors or decorate inventories.

Tests:
- Add unit tests covering battle and steal mode configuration defaults, steal state bookkeeping, mode player-flow defaults, and the new player lobby hook behaviour.