### PR TITLE
feat(regen): implement regeneration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,11 +12,11 @@ allprojects {
     description = property("description") as String
 
     repositories {
-        mavenCentral()
         maven {
             name = "papermc-repo"
             url = uri("https://repo.papermc.io/repository/maven-public/")
         }
+        mavenCentral()
     }
 }
 

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/core/bootstrap/module/RegenerationModule.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/core/bootstrap/module/RegenerationModule.java
@@ -1,0 +1,90 @@
+package top.ourisland.creepersiarena.core.bootstrap.module;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import org.bukkit.Bukkit;
+import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
+import top.ourisland.creepersiarena.config.ConfigManager;
+import top.ourisland.creepersiarena.core.bootstrap.BootstrapRuntime;
+import top.ourisland.creepersiarena.core.bootstrap.IBootstrapModule;
+import top.ourisland.creepersiarena.core.bootstrap.ListenerBinder;
+import top.ourisland.creepersiarena.core.bootstrap.StageTask;
+import top.ourisland.creepersiarena.core.component.annotation.CiaBootstrapModule;
+import top.ourisland.creepersiarena.game.GameManager;
+import top.ourisland.creepersiarena.game.listener.RegenerationListener;
+import top.ourisland.creepersiarena.game.regeneration.RegenerationService;
+import top.ourisland.creepersiarena.job.skill.ui.SkillItemCodec;
+
+@CiaBootstrapModule(name = "regeneration", order = 1150)
+public final class RegenerationModule implements IBootstrapModule {
+
+    @Override
+    public String name() {
+        return "regeneration";
+    }
+
+    @Override
+    public StageTask install(BootstrapRuntime rt) {
+        return StageTask.of(() -> {
+            var service = new RegenerationService(
+                    rt.log(),
+                    rt.requireService(ConfigManager.class),
+                    rt.requireService(PlayerSessionStore.class),
+                    rt.requireService(GameManager.class)
+            );
+            rt.putService(RegenerationService.class, service);
+        }, "Loading resting regeneration...", "Resting regeneration loaded.");
+    }
+
+    @Override
+    public StageTask start(BootstrapRuntime rt) {
+        return StageTask.of(() -> {
+            var service = rt.requireService(RegenerationService.class);
+            ScheduledTask task = Bukkit.getServer().getGlobalRegionScheduler().runAtFixedRate(
+                    rt.plugin(),
+                    _ -> service.tick(),
+                    1L,
+                    1L
+            );
+            rt.trackTask(task);
+            rt.putService(RegenerationTickHandle.class, new RegenerationTickHandle(task));
+        }, "Starting resting regeneration tick...", "Resting regeneration tick started.");
+    }
+
+    @Override
+    public StageTask stop(BootstrapRuntime rt) {
+        return StageTask.of(() -> {
+            var service = rt.getService(RegenerationService.class);
+            if (service != null) service.clearAll();
+
+            var handle = rt.getService(RegenerationTickHandle.class);
+            if (handle == null) return;
+            try {
+                handle.task().cancel();
+            } catch (Throwable _) {
+            }
+        }, "Stopping resting regeneration tick...", "Resting regeneration tick stopped.");
+    }
+
+    @Override
+    public StageTask reload(BootstrapRuntime rt) {
+        return StageTask.of(() -> {
+            var service = rt.requireService(RegenerationService.class);
+            service.reloadConfig();
+        }, "Reloading resting regeneration...", "Resting regeneration reloaded.");
+    }
+
+    @Override
+    public boolean registerListeners(ListenerBinder binder) {
+        var rt = binder.rt();
+        binder.register("RestingRegenerationListener", () -> new RegenerationListener(
+                rt.requireService(RegenerationService.class),
+                rt.getService(SkillItemCodec.class)
+        ));
+        return true;
+    }
+
+    public record RegenerationTickHandle(ScheduledTask task) {
+
+    }
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/core/extension/loading/CiaExtensionRuntimeContext.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/core/extension/loading/CiaExtensionRuntimeContext.java
@@ -5,6 +5,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import top.ourisland.creepersiarena.api.ICiaExtensionContext;
 import top.ourisland.creepersiarena.api.extension.CiaExtensionDescriptor;
@@ -65,11 +66,6 @@ final class CiaExtensionRuntimeContext implements ICiaExtensionContext {
     }
 
     @Override
-    public String extensionId() {
-        return descriptor.id();
-    }
-
-    @Override
     public Path dataFolder() {
         return dataFolder;
     }
@@ -77,12 +73,6 @@ final class CiaExtensionRuntimeContext implements ICiaExtensionContext {
     @Override
     public Plugin plugin() {
         return rt.plugin();
-    }
-
-    @Override
-    public <T> T getService(Class<T> type) {
-        Objects.requireNonNull(type, "type");
-        return rt == null ? null : rt.getService(type);
     }
 
     @Override
@@ -199,6 +189,16 @@ final class CiaExtensionRuntimeContext implements ICiaExtensionContext {
         var gm = rt == null ? null : rt.getService(GameManager.class);
         if (gm != null) gm.registerMode(descriptor.id(), mode);
         logInfo("[Extension] {} registered mode {}", descriptor.id(), mode.mode());
+    }
+
+    @Override
+    public String extensionId() {
+        return descriptor.id();
+    }
+
+    @Override
+    public <T> @Nullable T getService(@lombok.NonNull Class<T> type) {
+        return rt == null ? null : rt.getService(type);
     }
 
     @Override

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/listener/RegenerationListener.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/listener/RegenerationListener.java
@@ -1,0 +1,141 @@
+package top.ourisland.creepersiarena.game.listener;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.*;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.projectiles.ProjectileSource;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import top.ourisland.creepersiarena.game.regeneration.RegenerationBreakReason;
+import top.ourisland.creepersiarena.game.regeneration.RegenerationConfig;
+import top.ourisland.creepersiarena.game.regeneration.RegenerationService;
+import top.ourisland.creepersiarena.job.skill.ui.SkillItemCodec;
+
+import java.util.Objects;
+
+public final class RegenerationListener implements Listener {
+
+    private final RegenerationService regeneration;
+    private final SkillItemCodec skillItemCodec;
+
+    public RegenerationListener(
+            RegenerationService regeneration,
+            SkillItemCodec skillItemCodec
+    ) {
+        this.regeneration = regeneration;
+        this.skillItemCodec = skillItemCodec;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDamaged(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        regeneration.breakRest(player, RegenerationBreakReason.DAMAGED);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDealDamage(EntityDamageByEntityEvent event) {
+        var attacker = attackingPlayer(event);
+        if (attacker == null) return;
+        regeneration.breakRest(attacker, RegenerationBreakReason.DEALT_DAMAGE);
+    }
+
+    private @Nullable Player attackingPlayer(EntityDamageByEntityEvent event) {
+        if (event.getDamager() instanceof Player player) return player;
+        if (event.getDamager() instanceof Projectile projectile) {
+            ProjectileSource source = projectile.getShooter();
+            if (source instanceof Player player) return player;
+        }
+        return null;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onMove(PlayerMoveEvent event) {
+        var to = event.getTo();
+        if (!movedEnough(event.getFrom(), to, regeneration.config())) return;
+
+        var reason = to.getY() > event.getFrom().getY()
+                ? RegenerationBreakReason.JUMPED
+                : RegenerationBreakReason.MOVED;
+        regeneration.breakRest(event.getPlayer(), reason);
+    }
+
+    private boolean movedEnough(
+            @NonNull Location from,
+            @NonNull Location to,
+            @NonNull RegenerationConfig config
+    ) {
+        if (!Objects.equals(from.getWorld(), to.getWorld())) return true;
+
+        double dx = to.getX() - from.getX();
+        double dz = to.getZ() - from.getZ();
+        double dy = to.getY() - from.getY();
+        double horizontal = Math.hypot(dx, dz);
+
+        return horizontal > config.stationaryHorizontalEpsilon()
+                || Math.abs(dy) > config.maxVerticalDelta();
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onToggleSneak(PlayerToggleSneakEvent event) {
+        if (event.isSneaking()) return;
+        regeneration.breakRest(event.getPlayer(), RegenerationBreakReason.MOVED);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        if (event.getAction() == Action.PHYSICAL) return;
+        if (event.getItem() == null) return;
+
+        if (skillItemCodec != null && skillItemCodec.isSkillItem(event.getItem())) {
+            regeneration.breakRest(event.getPlayer(), RegenerationBreakReason.USED_SKILL);
+            return;
+        }
+
+        if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            regeneration.breakRest(event.getPlayer(), RegenerationBreakReason.USED_ITEM);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onShoot(EntityShootBowEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        regeneration.breakRest(player, RegenerationBreakReason.SHOT_PROJECTILE);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onConsume(PlayerItemConsumeEvent event) {
+        regeneration.breakRest(event.getPlayer(), RegenerationBreakReason.USED_ITEM);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onQuit(PlayerQuitEvent event) {
+        regeneration.clear(event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onKick(PlayerKickEvent event) {
+        regeneration.clear(event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onDeath(PlayerDeathEvent event) {
+        regeneration.clear(event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onTeleport(PlayerTeleportEvent event) {
+        regeneration.breakRest(event.getPlayer(), RegenerationBreakReason.LEFT_GAME);
+    }
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/IRegenerationEligibility.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/IRegenerationEligibility.java
@@ -1,0 +1,9 @@
+package top.ourisland.creepersiarena.game.regeneration;
+
+import org.bukkit.entity.Player;
+
+public interface IRegenerationEligibility {
+
+    boolean allowRegeneration(Player player);
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationBreakReason.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationBreakReason.java
@@ -1,0 +1,16 @@
+package top.ourisland.creepersiarena.game.regeneration;
+
+public enum RegenerationBreakReason {
+
+    MOVED,
+    JUMPED,
+    DAMAGED,
+    DEALT_DAMAGE,
+    USED_ITEM,
+    USED_SKILL,
+    SHOT_PROJECTILE,
+    LEFT_GAME,
+    OBJECTIVE_ACTION,
+    NO_LONGER_ELIGIBLE
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationConfig.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationConfig.java
@@ -1,0 +1,168 @@
+package top.ourisland.creepersiarena.game.regeneration;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import top.ourisland.creepersiarena.config.ConfigManager;
+
+import java.util.*;
+
+public record RegenerationConfig(
+        boolean enabled,
+        boolean requireInGame,
+        boolean requireTeam,
+        Set<Integer> validTeams,
+        double stationaryHorizontalEpsilon,
+        double maxVerticalDelta,
+        boolean requireOnGround,
+        boolean clearEffectOnBreak,
+        List<RegenerationStage> stages
+) {
+
+    private static final Set<Integer> DEFAULT_VALID_TEAMS = Set.of(1, 2, 3, 4);
+    private static final String DEFAULT_CHIME_SOUND = "minecraft:block.note_block.chime";
+    private static final String DEFAULT_BEACON_SOUND = "minecraft:block.beacon.ambient";
+
+    public static RegenerationConfig load(
+            @Nullable ConfigManager configManager,
+            @NonNull Logger logger
+    ) {
+        if (configManager == null) return defaults();
+
+        var path = configManager.dataDir().resolve("config.yml");
+        try {
+            var yaml = YamlConfiguration.loadConfiguration(path.toFile());
+            return fromSection(yaml.getConfigurationSection("game.regeneration"));
+        } catch (Throwable throwable) {
+            logger.warn(
+                    "[Regeneration] Failed to load game.regeneration from config.yml, using defaults: {}",
+                    throwable.getMessage(),
+                    throwable
+            );
+            return defaults();
+        }
+    }
+
+    public static RegenerationConfig defaults() {
+        return new RegenerationConfig(
+                true,
+                true,
+                true,
+                DEFAULT_VALID_TEAMS,
+                0.003D,
+                0.08D,
+                true,
+                true,
+                defaultStages()
+        );
+    }
+
+    static @NonNull RegenerationConfig fromSection(@Nullable ConfigurationSection section) {
+        RegenerationConfig defaults = defaults();
+        if (section == null) return defaults;
+
+        Set<Integer> validTeams = readValidTeams(section);
+        List<RegenerationStage> stages = readStages(section.getMapList("stages"));
+        if (stages.isEmpty()) stages = defaults.stages();
+
+        return new RegenerationConfig(
+                section.getBoolean("enabled", defaults.enabled()),
+                section.getBoolean("require-in-game", defaults.requireInGame()),
+                section.getBoolean("require-team", defaults.requireTeam()),
+                validTeams.isEmpty() ? defaults.validTeams() : Set.copyOf(validTeams),
+                Math.max(0.0D, section.getDouble("stationary-horizontal-epsilon", defaults.stationaryHorizontalEpsilon())),
+                Math.max(0.0D, section.getDouble("max-vertical-delta", defaults.maxVerticalDelta())),
+                section.getBoolean("require-on-ground", defaults.requireOnGround()),
+                section.getBoolean("clear-effect-on-break", defaults.clearEffectOnBreak()),
+                List.copyOf(stages)
+        );
+    }
+
+    private static @NonNull List<RegenerationStage> defaultStages() {
+        return List.of(
+                new RegenerationStage(20, 40, 0, DEFAULT_CHIME_SOUND, 20.0F, 0.2F),
+                new RegenerationStage(40, 40, 0, DEFAULT_CHIME_SOUND, 20.0F, 0.9F),
+                new RegenerationStage(60, 40, 1, DEFAULT_CHIME_SOUND, 20.0F, 1.2F),
+                new RegenerationStage(80, 40, 1, DEFAULT_BEACON_SOUND, 1.5F, 2.0F),
+                new RegenerationStage(105, 40, 2, DEFAULT_BEACON_SOUND, 1.25F, 2.0F),
+                new RegenerationStage(130, 40, 2, DEFAULT_BEACON_SOUND, 1.0F, 2.0F),
+                new RegenerationStage(155, 40, 3, DEFAULT_BEACON_SOUND, 0.75F, 2.0F),
+                new RegenerationStage(180, 60, 3, DEFAULT_BEACON_SOUND, 0.5F, 2.0F),
+                new RegenerationStage(210, 60, 4, DEFAULT_BEACON_SOUND, 0.4F, 2.0F),
+                new RegenerationStage(240, 60, 5, DEFAULT_BEACON_SOUND, 0.3F, 2.0F),
+                new RegenerationStage(270, 60, 6, DEFAULT_BEACON_SOUND, 0.25F, 2.0F),
+                new RegenerationStage(300, 60, 7, DEFAULT_BEACON_SOUND, 0.15F, 2.0F),
+                new RegenerationStage(330, 60, 8, DEFAULT_BEACON_SOUND, 0.1F, 2.0F)
+        );
+    }
+
+    private static @NonNull Set<Integer> readValidTeams(@NonNull ConfigurationSection section) {
+        var out = new LinkedHashSet<Integer>();
+        for (var raw : section.getStringList("valid-teams")) {
+            try {
+                out.add(Integer.parseInt(raw.trim()));
+            } catch (NumberFormatException _) {
+            }
+        }
+        if (!out.isEmpty()) return out;
+
+        out.addAll(section.getIntegerList("valid-teams"));
+        return out;
+    }
+
+    private static @NonNull List<RegenerationStage> readStages(List<Map<?, ?>> rawStages) {
+        var out = new ArrayList<RegenerationStage>();
+        if (rawStages == null) return out;
+
+        for (var rawStage : rawStages) {
+            int tick = readInt(rawStage.get("tick"), -1);
+            int durationTicks = readInt(rawStage.get("duration-ticks"), -1);
+            int amplifier = Math.max(0, readInt(rawStage.get("amplifier"), 0));
+            String sound = readString(rawStage.get("sound"), DEFAULT_BEACON_SOUND);
+            float volume = Math.max(0.0F, readFloat(rawStage.get("volume"), 1.0F));
+            float pitch = Math.max(0.0F, readFloat(rawStage.get("pitch"), 1.0F));
+
+            if (tick <= 0 || durationTicks <= 0) continue;
+            out.add(new RegenerationStage(
+                    tick,
+                    durationTicks,
+                    amplifier,
+                    sound,
+                    volume,
+                    pitch
+            ));
+        }
+
+        out.sort(Comparator.comparingInt(RegenerationStage::tick));
+        return out;
+    }
+
+    private static int readInt(Object value, int fallback) {
+        if (value instanceof Number number) return number.intValue();
+        if (value == null) return fallback;
+        try {
+            return Integer.parseInt(value.toString().trim());
+        } catch (NumberFormatException _) {
+            return fallback;
+        }
+    }
+
+    private static String readString(Object value, String fallback) {
+        if (value == null) return fallback;
+        String string = value.toString().trim();
+        return string.isEmpty() ? fallback : string;
+    }
+
+    private static float readFloat(Object value, float fallback) {
+        if (value instanceof Number number) return number.floatValue();
+        if (value == null) return fallback;
+        try {
+            return Float.parseFloat(value.toString().trim());
+        } catch (NumberFormatException _) {
+            return fallback;
+        }
+    }
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationService.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationService.java
@@ -1,0 +1,176 @@
+package top.ourisland.creepersiarena.game.regeneration;
+
+import org.bukkit.Bukkit;
+import org.bukkit.SoundCategory;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import top.ourisland.creepersiarena.api.game.GameSession;
+import top.ourisland.creepersiarena.api.game.mode.IModeTimeline;
+import top.ourisland.creepersiarena.api.game.player.PlayerSession;
+import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
+import top.ourisland.creepersiarena.api.game.player.PlayerState;
+import top.ourisland.creepersiarena.config.ConfigManager;
+import top.ourisland.creepersiarena.game.GameManager;
+import top.ourisland.creepersiarena.utils.PlayerMotionChecks;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static top.ourisland.creepersiarena.utils.PlayerMotionChecks.isServerSideGrounded;
+
+public final class RegenerationService {
+
+    private final Logger logger;
+    private final ConfigManager configManager;
+    private final PlayerSessionStore sessions;
+    private final GameManager gameManager;
+    private final Map<UUID, RegenerationState> states = new HashMap<>();
+
+    private RegenerationConfig config = RegenerationConfig.defaults();
+
+    public RegenerationService(
+            Logger logger,
+            ConfigManager configManager,
+            PlayerSessionStore sessions,
+            GameManager gameManager
+    ) {
+        this.logger = logger;
+        this.configManager = configManager;
+        this.sessions = sessions;
+        this.gameManager = gameManager;
+        reloadConfig();
+    }
+
+    public void reloadConfig() {
+        config = RegenerationConfig.load(configManager, logger);
+        if (!config.enabled()) clearAll();
+    }
+
+    public void clearAll() {
+        if (config.clearEffectOnBreak()) {
+            for (var playerId : states.keySet()) {
+                var player = Bukkit.getPlayer(playerId);
+                if (player != null) player.removePotionEffect(PotionEffectType.REGENERATION);
+            }
+        }
+        states.clear();
+    }
+
+    public RegenerationConfig config() {
+        return config;
+    }
+
+    public void tick() {
+        var currentConfig = config;
+        if (!currentConfig.enabled()) {
+            clearAll();
+            return;
+        }
+
+        for (var player : Bukkit.getOnlinePlayers()) {
+            tickPlayer(player, currentConfig);
+        }
+    }
+
+    private void tickPlayer(Player player, RegenerationConfig currentConfig) {
+        if (!canRegenerate(player, currentConfig)) {
+            breakRest(player, RegenerationBreakReason.NO_LONGER_ELIGIBLE);
+            return;
+        }
+
+        var state = states.computeIfAbsent(
+                player.getUniqueId(),
+                _ -> new RegenerationState()
+        );
+        int currentTick = state.advance();
+
+        for (var stage : currentConfig.stages()) {
+            if (stage.tick() != currentTick || !state.markStageFired(stage.tick())) continue;
+            applyStage(player, stage);
+        }
+    }
+
+    private boolean canRegenerate(Player player, RegenerationConfig currentConfig) {
+        PlayerSession session = sessions.get(player);
+        if (session == null) return false;
+        if (currentConfig.requireInGame() && session.state() != PlayerState.IN_GAME) return false;
+
+        GameSession active = gameManager.active();
+        if (active == null || !active.players().contains(player.getUniqueId())) return false;
+
+        if (currentConfig.requireTeam()) {
+            Integer selectedTeam = session.selectedTeam();
+            if (selectedTeam == null || !currentConfig.validTeams().contains(selectedTeam)) return false;
+        }
+
+        IModeTimeline timeline = gameManager.timeline();
+        if (timeline instanceof IRegenerationEligibility eligibility
+                && !eligibility.allowRegeneration(player)) {
+            return false;
+        }
+
+        return player.isSneaking() && isRestingStill(player, currentConfig);
+    }
+
+    public void breakRest(
+            @Nullable Player player,
+            @Nullable RegenerationBreakReason reason
+    ) {
+        if (player == null) return;
+        var removed = states.remove(player.getUniqueId());
+        if (removed == null) return;
+        if (removed.restingTicks() <= 0) return;
+
+        if (config.clearEffectOnBreak()) {
+            player.removePotionEffect(PotionEffectType.REGENERATION);
+        }
+    }
+
+    private void applyStage(Player player, RegenerationStage stage) {
+        player.addPotionEffect(new PotionEffect(
+                PotionEffectType.REGENERATION,
+                stage.durationTicks(),
+                stage.amplifier(),
+                false,
+                true,
+                true
+        ));
+
+        try {
+            player.playSound(
+                    player.getLocation(),
+                    stage.sound(),
+                    SoundCategory.PLAYERS,
+                    stage.volume(),
+                    stage.pitch()
+            );
+        } catch (IllegalArgumentException exception) {
+            logger.warn("[Regeneration] Invalid configured sound '{}': {}", stage.sound(), exception.getMessage());
+        }
+    }
+
+    private boolean isRestingStill(Player player, RegenerationConfig currentConfig) {
+        if (currentConfig.requireOnGround() && !isServerSideGrounded(player)) return false;
+        if (player.isSprinting()) return false;
+        if (player.isSwimming()) return false;
+        if (player.isGliding()) return false;
+        if (player.isFlying()) return false;
+
+        Vector velocity = player.getVelocity();
+        double horizontal = Math.hypot(velocity.getX(), velocity.getZ());
+        if (horizontal > currentConfig.stationaryHorizontalEpsilon()) return false;
+
+        return Math.abs(velocity.getY()) <= currentConfig.maxVerticalDelta();
+    }
+
+    public void clear(Player player) {
+        if (player == null) return;
+        states.remove(player.getUniqueId());
+    }
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationStage.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationStage.java
@@ -1,0 +1,14 @@
+package top.ourisland.creepersiarena.game.regeneration;
+
+import org.jspecify.annotations.NonNull;
+
+public record RegenerationStage(
+        int tick,
+        int durationTicks,
+        int amplifier,
+        @NonNull String sound,
+        float volume,
+        float pitch
+) {
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationState.java
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/game/regeneration/RegenerationState.java
@@ -1,0 +1,24 @@
+package top.ourisland.creepersiarena.game.regeneration;
+
+import java.util.HashSet;
+import java.util.Set;
+
+final class RegenerationState {
+
+    private final Set<Integer> firedStages = new HashSet<>();
+    private int restingTicks;
+
+    int advance() {
+        restingTicks++;
+        return restingTicks;
+    }
+
+    int restingTicks() {
+        return restingTicks;
+    }
+
+    boolean markStageFired(int tick) {
+        return firedStages.add(tick);
+    }
+
+}

--- a/cia-core/src/main/java/top/ourisland/creepersiarena/utils/PlayerMotionChecks.kt
+++ b/cia-core/src/main/java/top/ourisland/creepersiarena/utils/PlayerMotionChecks.kt
@@ -1,0 +1,50 @@
+package top.ourisland.creepersiarena.utils
+
+import org.bukkit.FluidCollisionMode
+import org.bukkit.Location
+import org.bukkit.World
+import org.bukkit.entity.Entity
+import org.bukkit.util.BoundingBox
+import org.bukkit.util.Vector
+
+object PlayerMotionChecks {
+
+    private val DOWN = Vector(0, -1, 0)
+
+    @JvmStatic
+    fun isServerSideGrounded(entity: Entity): Boolean {
+        val box: BoundingBox = entity.boundingBox
+        val world: World = entity.world
+
+        val y = box.minY + 0.01
+        val maxDistance = 0.08
+
+        val minX = box.minX + 0.03
+        val maxX = box.maxX - 0.03
+        val minZ = box.minZ + 0.03
+        val maxZ = box.maxZ - 0.03
+        val midX = (minX + maxX) / 2.0
+        val midZ = (minZ + maxZ) / 2.0
+
+        fun hitsGround(
+            world: World,
+            x: Double,
+            y: Double,
+            z: Double,
+            distance: Double
+        ): Boolean = world.rayTraceBlocks(
+            Location(world, x, y, z),
+            DOWN,
+            distance,
+            FluidCollisionMode.NEVER,
+            true
+        ) != null
+
+        return hitsGround(world, minX, y, minZ, maxDistance) ||
+                hitsGround(world, minX, y, maxZ, maxDistance) ||
+                hitsGround(world, maxX, y, minZ, maxDistance) ||
+                hitsGround(world, maxX, y, maxZ, maxDistance) ||
+                hitsGround(world, midX, y, midZ, maxDistance)
+    }
+
+}

--- a/cia-core/src/main/resources/config.yml
+++ b/cia-core/src/main/resources/config.yml
@@ -25,6 +25,96 @@ game:
   # Shared game-level settings owned by core.
   leave-delay-seconds: 5
 
+  # Core-owned resting regeneration ability. Players can heal by sneaking without moving while in game.
+  regeneration:
+    enabled: true
+    require-in-game: true
+    require-team: true
+    valid-teams: [ 1, 2, 3, 4 ]
+    stationary-horizontal-epsilon: 0.003
+    max-vertical-delta: 0.08
+    require-on-ground: true
+    clear-effect-on-break: true
+    stages:
+      - tick: 20
+        duration-ticks: 40
+        amplifier: 0
+        sound: minecraft:block.note_block.chime
+        volume: 20.0
+        pitch: 0.2
+      - tick: 40
+        duration-ticks: 40
+        amplifier: 0
+        sound: minecraft:block.note_block.chime
+        volume: 20.0
+        pitch: 0.9
+      - tick: 60
+        duration-ticks: 40
+        amplifier: 1
+        sound: minecraft:block.note_block.chime
+        volume: 20.0
+        pitch: 1.2
+      - tick: 80
+        duration-ticks: 40
+        amplifier: 1
+        sound: minecraft:block.beacon.ambient
+        volume: 1.5
+        pitch: 2.0
+      - tick: 105
+        duration-ticks: 40
+        amplifier: 2
+        sound: minecraft:block.beacon.ambient
+        volume: 1.25
+        pitch: 2.0
+      - tick: 130
+        duration-ticks: 40
+        amplifier: 2
+        sound: minecraft:block.beacon.ambient
+        volume: 1.0
+        pitch: 2.0
+      - tick: 155
+        duration-ticks: 40
+        amplifier: 3
+        sound: minecraft:block.beacon.ambient
+        volume: 0.75
+        pitch: 2.0
+      - tick: 180
+        duration-ticks: 60
+        amplifier: 3
+        sound: minecraft:block.beacon.ambient
+        volume: 0.5
+        pitch: 2.0
+      - tick: 210
+        duration-ticks: 60
+        amplifier: 4
+        sound: minecraft:block.beacon.ambient
+        volume: 0.4
+        pitch: 2.0
+      - tick: 240
+        duration-ticks: 60
+        amplifier: 5
+        sound: minecraft:block.beacon.ambient
+        volume: 0.3
+        pitch: 2.0
+      - tick: 270
+        duration-ticks: 60
+        amplifier: 6
+        sound: minecraft:block.beacon.ambient
+        volume: 0.25
+        pitch: 2.0
+      - tick: 300
+        duration-ticks: 60
+        amplifier: 7
+        sound: minecraft:block.beacon.ambient
+        volume: 0.15
+        pitch: 2.0
+      - tick: 330
+        duration-ticks: 60
+        amplifier: 8
+        sound: minecraft:block.beacon.ambient
+        volume: 0.1
+        pitch: 2.0
+
 ui:
   lobby:
     job-select-mode: hotbar

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/defaultcontent/DefaultContentExtension.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/defaultcontent/DefaultContentExtension.java
@@ -11,6 +11,7 @@ import top.ourisland.creepersiarena.game.death.DamageAttributionStore;
 import top.ourisland.creepersiarena.game.mode.impl.battle.BattleGameplayListener;
 import top.ourisland.creepersiarena.game.mode.impl.battle.BattleRespawnPresentation;
 import top.ourisland.creepersiarena.game.mode.impl.steal.runtime.StealGameplayListener;
+import top.ourisland.creepersiarena.game.regeneration.RegenerationService;
 import top.ourisland.creepersiarena.job.listener.SkillImplementationListener;
 import top.ourisland.creepersiarena.job.skill.SkillTickTask;
 import top.ourisland.creepersiarena.job.skill.runtime.SkillRuntime;
@@ -52,6 +53,7 @@ public final class DefaultContentExtension implements ICiaExtension {
         var runtime = context.requireService(SkillRuntime.class);
         var tickTask = context.requireService(SkillTickTask.class);
         var gameManager = context.requireService(GameManager.class);
+        var regeneration = context.getService(RegenerationService.class);
 
         BuiltinCombatUtils.installSessions(sessions);
         registerDeathContent(context, sessions, runtime);
@@ -60,7 +62,7 @@ public final class DefaultContentExtension implements ICiaExtension {
         context.registerListener(new BuiltinKillFeedbackService());
         context.registerListener(new BattleGameplayListener(gameManager, sessions));
         context.registerListener(new BattleRespawnPresentation(context.plugin(), gameManager, sessions));
-        context.registerListener(new StealGameplayListener(gameManager, sessions));
+        context.registerListener(new StealGameplayListener(gameManager, sessions, regeneration));
     }
 
     private void registerDeathContent(

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
@@ -95,7 +95,9 @@ public final class StealGameplayListener implements Listener {
         boolean accepted = active.timeline().onMinedRedstone(player, active.state().modeConfig());
         if (!accepted) return false;
 
-        regeneration.breakRest(player, RegenerationBreakReason.OBJECTIVE_ACTION);
+        if (regeneration != null) {
+            regeneration.breakRest(player, RegenerationBreakReason.OBJECTIVE_ACTION);
+        }
 
         block.setType(Material.AIR, false);
         player.playSound(player, Sound.BLOCK_DEEPSLATE_BREAK, SoundCategory.BLOCKS, 1.0f, 1.0f);

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealGameplayListener.java
@@ -20,6 +20,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.projectiles.ProjectileSource;
+import org.jspecify.annotations.Nullable;
 import top.ourisland.creepersiarena.api.game.GameSession;
 import top.ourisland.creepersiarena.api.game.event.ArenaPlayerDeathResolvedEvent;
 import top.ourisland.creepersiarena.api.game.mode.GameModeType;
@@ -28,15 +29,23 @@ import top.ourisland.creepersiarena.api.game.player.PlayerSessionStore;
 import top.ourisland.creepersiarena.api.game.player.PlayerState;
 import top.ourisland.creepersiarena.game.GameManager;
 import top.ourisland.creepersiarena.game.mode.impl.steal.model.StealTeam;
+import top.ourisland.creepersiarena.game.regeneration.RegenerationBreakReason;
+import top.ourisland.creepersiarena.game.regeneration.RegenerationService;
 
 public final class StealGameplayListener implements Listener {
 
     private final GameManager gameManager;
     private final PlayerSessionStore sessions;
+    private final RegenerationService regeneration;
 
-    public StealGameplayListener(GameManager gameManager, PlayerSessionStore sessions) {
+    public StealGameplayListener(
+            GameManager gameManager,
+            PlayerSessionStore sessions,
+            RegenerationService regeneration
+    ) {
         this.gameManager = gameManager;
         this.sessions = sessions;
+        this.regeneration = regeneration;
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -77,10 +86,16 @@ public final class StealGameplayListener implements Listener {
         return material == Material.DEEPSLATE_REDSTONE_ORE || material == Material.REDSTONE_ORE;
     }
 
-    private boolean tryMineRedstone(Player player, Block block, ActiveSteal active) {
+    private boolean tryMineRedstone(
+            @Nullable Player player,
+            @Nullable Block block,
+            @Nullable ActiveSteal active
+    ) {
         if (player == null || block == null || active == null) return false;
         boolean accepted = active.timeline().onMinedRedstone(player, active.state().modeConfig());
         if (!accepted) return false;
+
+        regeneration.breakRest(player, RegenerationBreakReason.OBJECTIVE_ACTION);
 
         block.setType(Material.AIR, false);
         player.playSound(player, Sound.BLOCK_DEEPSLATE_BREAK, SoundCategory.BLOCKS, 1.0f, 1.0f);

--- a/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
+++ b/cia-default-content/src/main/java/top/ourisland/creepersiarena/game/mode/impl/steal/runtime/StealTimeline.java
@@ -20,11 +20,12 @@ import top.ourisland.creepersiarena.api.game.player.PlayerSession;
 import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealArenaConfig;
 import top.ourisland.creepersiarena.game.mode.impl.steal.config.StealModeConfig;
 import top.ourisland.creepersiarena.game.mode.impl.steal.model.StealTeam;
+import top.ourisland.creepersiarena.game.regeneration.IRegenerationEligibility;
 import top.ourisland.creepersiarena.utils.Msg;
 
 import java.util.*;
 
-final class StealTimeline implements IModeTimeline {
+final class StealTimeline implements IModeTimeline, IRegenerationEligibility {
 
     private final GameRuntime runtime;
     private final GameSession session;
@@ -68,6 +69,13 @@ final class StealTimeline implements IModeTimeline {
     @Override
     public void onStop(TickContext ctx) {
         state.bossBars.hideAllTracked();
+    }
+
+    @Override
+    public boolean allowRegeneration(Player player) {
+        if (player == null || state.phase != StealPhase.ROUND_PLAYING) return false;
+        var playerId = player.getUniqueId();
+        return state.isParticipant(playerId) && state.isAlive(playerId);
     }
 
     GameRuntime runtime() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlinx-coroutines = "1.11.0"
 run-paper = "3.0.2"
 
 minecraft = "26.1.2"
-paper-api = "26.1.2.build.53-stable"
+paper-api = "26.1.2.build.69-stable"
 
 luckperms = "5.5"
 


### PR DESCRIPTION
close: #42

## Summary by Sourcery

Introduce a configurable, resting-based player regeneration system integrated into the core game loop and Steal mode.

New Features:
- Add a core regeneration service that grants staged regeneration effects to eligible, sneaking players while stationary in-game.
- Expose a configuration schema and defaults for regeneration behavior, including movement thresholds, team restrictions, and multi-stage healing with sounds.
- Provide a regeneration listener that monitors player actions and cancels resting regeneration when they move, take or deal damage, use items/skills, or leave the game.
- Integrate regeneration eligibility into the Steal game mode and break regeneration on redstone mining objective actions.
- Add a regeneration bootstrap module to wire the service, ticking task, and listeners into the server lifecycle.

Enhancements:
- Update dependency repositories order and bump the Paper API version used by the build.