### PR TITLE
build(26.2): bump minecraft version to 26.2 and paper-api version to 26.2.build.71-beta

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@ kotlin = "2.4.10"
 kotlinx-coroutines = "1.11.0"
 run-paper = "3.0.2"
 
-minecraft = "26.1.2"
-paper-api = "26.1.2.build.72-stable"
+minecraft = "26.2"
+paper-api = "26.2.build.71-beta"
 
 luckperms = "5.5"
 


### PR DESCRIPTION
## Summary by Sourcery

Update Minecraft and Paper API dependency versions to 26.2 and 26.2.build.71-beta in the Gradle version catalog.

Build:
- Bump Minecraft dependency to version 26.2.
- Bump Paper API dependency to version 26.2.build.71-beta.